### PR TITLE
reworked upcasting and circle mechanics for Mambo Marino

### DIFF
--- a/rhythmancy.md
+++ b/rhythmancy.md
@@ -403,11 +403,11 @@ _3rd-level conjuration/rhythmancy (Ritual)_
 - **Casting Time:** 1 minute
 - **Range:** 10 feet
 - **Components:** V, M (a mola scale; a musical instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 24 hours
+- **Duration:** Concentration, up to 8 hours
 
-You create a glowing 10-foot-diameter circle in a body of water you can see within range. The circle lasts for the spell's duration. At any time before the spell ends, as an action, you and any willing creatures you can see within 30 feet of you can attempt to teleport to the circle. If the space is occupied or cannot accommodate all the creatures you specify, the teleportation fails. Otherwise, any creatures teleported by this spell instantly appear within the circle, and the spell ends.
+You create a glowing 10-foot-diameter circle in the surface of a body of water you can see within range. The circle lasts for the spell's duration. At any time before the spell ends, as an action, you and any willing creatures you can see within 30 feet of you can attempt to teleport to the circle. If the circle is more than 1 mile away, or if the circle's space is occupied or cannot accommodate all the creatures you specify, the teleportation fails. Otherwise, any creatures teleported by this spell instantly appear within the circle, and the spell ends.
 
-**At Higher Levels.** When you cast this spell using a spell slot of 4th-level or higher, concentration is no longer required to maintain the spell, and for each spell level above 3rd, the diameter of the glowing circle you create increases by 10 feet and the duration is doubled. Additionally, if any circles exist from your previous castings of the spell, they continue to function and inherit the new spell duration.
+**At Higher Levels.** When you cast this spell using a spell slot of 4th-level or higher, for each spell level above 3rd: the diameter of the glowing circle you create increases by 10 feet; the spell's duration increases to 1 day (5th-level), 1 week (7th-level), or 1 month (9th-level); and when you cast this spell using a spell slot of 7th-level or higher, it lasts for the full duration. Additionally, if you cast this spell again before the duration ends, any circles that existed from your previous casting of the spell continue to function and inherit the new duration, unless you are more than 1 mile away from an existing circle, in which case all such circles disappear. While multiple circles exist, you can choose any of them as a destination when teleporting using this spell.
 
 #### [Melody of Darkness](https://github.com/mpanighetti/dnd5e-spells/blob/main/5th-level/melody-of-darkness.md)
 


### PR DESCRIPTION
- Mambo Marino changes:
  - reduced duration to 8 hours and set the upcasting durations to fixed thresholds rather than doubling
  - required circle to be in surface of water
  - made teleport fail if circle is > 1 mile away
  - made upcasting require concentration until 7th-level
  - made existing circles disappear if > 1 mile away when spell is recast