### PR TITLE
wrote The Curse Reversed, renamed many spells

### DIFF
--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -23,8 +23,8 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 2 | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | C |
 | 2 | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | C, M |
 | 2 | _[Song of Discovery](#song-of-discovery)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
+| 3 | _[The Cleansing Waves](#the-cleansing-waves)_ | Abjuration/Rhythmancy | Bard | C |
 | 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
-| 3 | _[New Wave Bossa Nova](#new-wave-bossa-nova)_ | Abjuration/Rhythmancy | Bard | C |
 | 3 | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | C |
 | 3 | _[Royal Duet](#royal-duet)_ | Evocation/Rhythmancy | Bard | D |
 | 3 | _[Song of Double Time](#song-of-double-time)_ | Abjuration/Rhythmancy | Bard | — |
@@ -75,6 +75,17 @@ _Abjuration/Rhythmancy Cantrip (Bard)_
 **Duration:** 10 minutes
 
 You play a soothing melody that conjures strange memories of a dream-like world. Until the spell ends, magic can't put you to sleep.
+
+### _The Cleansing Waves_
+
+_Level 3 Abjuration/Rhythmancy (Bard)_
+
+**Casting Time:** Action\
+**Range:** Self\
+**Components:** V (functions even if you are in an area affected by magical silence), S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 minute
+
+Until the spell ends, an aura of spectral water and healing energy surrounds you in a 10-foot Emanation. While in the aura, creatures are immune to the effects of magical silence, such as the _Silence_ spell, and the effects of magical Darkness, such as the _Darkness_ spell. Such creatures can speak, hear, and see normally, and they are able to use Verbal components to cast spells. The aura does not dispel any spells or magical effects causing silence or Darkness, but if the aura is contained completely within an area of magical silence or magical Darkness, any such magical sound or light stops at the edge of the sphere and cannot travel in or out of it.
 
 ### _Command Melody_
 
@@ -251,17 +262,6 @@ Everything the creature is wearing and carrying changes size with them. Any item
 While reduced in this manner, the target's speed is halved; they have disadvantage on Strength checks and Strength saving throws; they lose any Resistance or Immunity they have to nonmagical damage; and all of their attacks using either natural weapons or any reduced weapons deal 3d6 less damage (this can't reduce the damage below 1).
 
 The spell ends if you are unable to see the target.
-
-### _New Wave Bossa Nova_
-
-_Level 3 Abjuration/Rhythmancy (Bard)_
-
-**Casting Time:** Action\
-**Range:** Self (10-foot sphere)\
-**Components:** V (functions even if you are in an area affected by magical silence), S, M (a Musical Instrument worth 1+ GP)\
-**Duration:** Concentration, up to 1 minute
-
-Until the spell ends, you create a sphere of healing energy that negates the effects of magical silence, such as the _Silence_ spell, and the effects of magical darkness, such as the _Darkness_ spell. The sphere moves with you. Creatures within this sphere hear normally in magical silence and see normally in magical darkness, and can speak, hear, see, and cast spells normally. Any spells or magical effects causing silence or darkness are not dispelled, but they cannot affect any creatures within the negating sphere. If the negating sphere is contained completely within an area of magical silence or magical darkness, any such magical sound or light stops at the edge of the sphere and cannot travel in or out of it.
 
 ### _Oath to Order_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -24,11 +24,11 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 2 | _[Stirring Sonata](#stirring-sonata)_ | Abjuration/Rhythmancy | Bard | C, M |
 | 2 | _[Souls Entwined](#souls-entwined)_ | Conjuration/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Cleansing Waves](#the-cleansing-waves)_ | Abjuration/Rhythmancy | Bard | C |
+| 3 | _[Concerto No. 1 in E major, "Echoes of the Past"](#concerto-no-1-in-e-major-echoes-of-the-past)_ | Divination/Rhythmancy | Bard | C, R, M |
 | 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
 | 3 | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | C |
 | 3 | _[Royal Duet](#royal-duet)_ | Evocation/Rhythmancy | Bard | D |
 | 3 | _[Song of Double Time](#song-of-double-time)_ | Abjuration/Rhythmancy | Bard | — |
-| 3 | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Wind in My Sails](#the-wind-in-my-sails)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 4 | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | C |
 | 4 | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | C |
@@ -36,13 +36,13 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 4 | _[The Sage of Wind's Beckoning](#the-sage-of-winds-beckoning)_ | Evocation/Rhythmancy | Bard | M |
 | 4 | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | M |
 | 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | R, M |
+| 5 | _[Concerto No. 2 in G minor, "Ripples of the Current"](#concerto-no-2-in-g-minor-ripples-of-the-current)_ | Abjuration/Rhythmancy | Bard | M |
 | 5 | _[Healing Balm](#healing-balm)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
 | 5 | _[Ballet of the Moon and Sun](#ballet-of-the-moon-and-sun)_ | Illusion/Rhythmancy | Bard | C |
-| 5 | _[Tune of Currents](#tune-of-currents)_ | Abjuration/Rhythmancy | Bard | M |
 | 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
-| 7 | _[Tune of Ages](#tune-of-ages)_ | Conjuration/Rhythmancy | Bard | M |
+| 7 | _[Concerto No. 3 in F minor, "Master of the Ages"](#concerto-no-3-in-f-minor-master-of-the-ages)_ | Conjuration/Rhythmancy | Bard | M |
 | 8 | _[Cast Upon the Seas](#cast-upon-the-seas)_ | Conjuration/Rhythmancy | Bard | M |
 | 8 | _[Hold Back the Skies](#hold-back-the-skies)_ | Abjuration/Rhythmancy | Bard | M |
 
@@ -513,39 +513,7 @@ A Medium-sized inanimate scarecrow appears anchored to the ground in an unoccupi
 
 The scarecrow can act as a target for a thrown grappling hook or similar equipment, and it can support up to 500 pounds of weight. It disappears when you cast this spell again.
 
-### _Tune of Ages_
-
-_Level 7 Conjuration/Rhythmancy (Bard)_
-
-**Casting Time:** 1 hour\
-**Range:** 30 feet\
-**Components:** V, S, M (a magic item or a willing creature from the destination time period; a Musical Instrument worth 1+ GP)\
-**Duration:** Instantaneous
-
-You and up to eight willing creatures within range are removed from your current time period and appear in the same physical location in another time period you choose.
-
-The selected time period must at least specify the destination year, but can be more specific if desired. Additionally, the magic item or willing creature specified in the spell's material components must have existed in the time period you specify and must accompany you in the time travel. If any of these conditions are not met, the spell fails.
-
-### _Tune of Currents_
-
-_Level 5 Abjuration/Rhythmancy (Bard)_
-
-**Casting Time:** 1 minute\
-**Range:** 30 feet\
-**Components:** V, M (a Musical Instrument worth 1+ GP; an item that tells time worth 200 gp which the spell consumes)\
-**Duration:** Instantaneous
-
-You attempt to restore the normal flow of time for a creature you can see within range. This spell can potentially remove the following temporal effects from the target:
-
-- Any spell or magical effect on the target that caused them to grow older or younger
-- Any spell or magical effect that caused the target to be removed from their original time period
-- _Haste_, _Slow_, and any chronurgy spell [^⏳]
-
-Any ongoing spell of level 5 or lower on the target that falls under one of the above criteria ends, similar to the effect of _Dispel Magic_; additionally, any valid spell for which you were originally the caster and any valid magical effect not caused by a spell ends. A creature magically displaced from their original time period is immediately returned to their era, and all magical aging is removed.
-
-[^⏳]: Source: _Explorer's Guide to Wildemount_
-
-### _Tune of Echoes_
+### _Concerto No. 1 in E major, "Echoes of the Past"_
 
 _Level 3 Divination/Rhythmancy (Bard)_
 
@@ -559,6 +527,38 @@ You create an image in the air 10 feet in front of you depicting your current ge
 For the duration of the spell, the image plays out the selected moment in real time. The image can display any location within 100 feet of where the spell was cast, switching focus as needed to depict the selected moment as fully as possible. You can see and hear through the image as if you were present at that point in time. If, at any point during the playback of the selected moment, a magical effect was present which blocked detection through Divination magic or being perceived through magical scrying sensors (such as with the _Nondetection_ spell), the image becomes unfocused and the sound becomes distorted until such a time that the magical effect ended or was not present.
 
 Any number of times before the spell ends, as a Magic action, you can spend an additional spell slot of any level to extend the spell's duration by a number of minutes equal to ten times the slot level.
+
+### _Concerto No. 2 in G minor, "Ripples of the Current"_
+
+_Level 5 Abjuration/Rhythmancy (Bard)_
+
+**Casting Time:** 1 minute\
+**Range:** 30 feet\
+**Components:** V, M (a Musical Instrument worth 1+ GP; an item that tells time worth 200 gp which the spell consumes)\
+**Duration:** Instantaneous
+
+You attempt to restore the normal flow of time for a creature you can see within range. This spell can potentially remove the following temporal effects from the target:
+
+- Any spell or magical effect on the target that caused them to grow older or younger
+- Any spell or magical effect that caused the target to be removed from their original time period
+- _Haste_, _Slow_, and any Chronurgy spell [^⏳]
+
+Any ongoing spell of level 5 or lower on the target that falls under one of the above criteria ends, similar to the effect of _Dispel Magic_; additionally, any valid spell for which you were originally the caster and any valid magical effect not caused by a spell ends. A creature magically displaced from their original time period is immediately returned to their era, and all magical aging is removed.
+
+[^⏳]: Source: _Explorer's Guide to Wildemount_
+
+### _Concerto No. 3 in F minor, "Master of the Ages"_
+
+_Level 7 Conjuration/Rhythmancy (Bard)_
+
+**Casting Time:** 1 hour\
+**Range:** 30 feet\
+**Components:** V, S, M (a magic item or a willing creature from the destination time period; a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
+
+You and up to eight willing creatures within range are removed from your current time period and appear in the same physical location in another time period you choose.
+
+The selected time period must at least specify the destination year, but can be more specific if desired. Additionally, the magic item or willing creature specified in the spell's material components must have existed in the time period you specify and must accompany you in the time travel. If any of these conditions are not met, the spell fails.
 
 ### _The Wind in My Sails_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -14,15 +14,15 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard | |
 | 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | — |
 | 1 | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R |
-| 1 | _[Song of Storms](#song-of-storms)_ | Evocation/Rhythmancy | Bard | Concentration |
+| 1 | _[The Oncoming Storm](#the-oncoming-storm)_ | Evocation/Rhythmancy | Bard | Concentration |
 | 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 1 | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard | — |
 | 2 | _[Command Melody](#command-melody)_ | Conjuration/Rhythmancy | Bard | C, R, M |
 | 2 | _[Duet of Restoration](#duet-of-restoration)_ | Evocation/Rhythmancy | Bard | D |
-| 2 | _[Elegy of Emptiness](#elegy-of-emptiness)_ | Conjuration/Rhythmancy | Bard | — |
+| 2 | _[An Empty Shell](#an-empty-shell)_ | Conjuration/Rhythmancy | Bard | — |
+| 2 | _[No Stone Unturned](#no-stone-unturned)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 2 | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | C |
 | 2 | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | C, M |
-| 2 | _[Song of Discovery](#song-of-discovery)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 3 | _[The Cleansing Waves](#the-cleansing-waves)_ | Abjuration/Rhythmancy | Bard | C |
 | 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
 | 3 | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | C |
@@ -143,7 +143,7 @@ You and a partner play an uplifting Duet, targeting a shared location within ran
 
 _**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 3 or higher, all creatures that gained the benefits of a Short Rest from this spell also gain a number of Temporary Hit Points equal to twice the spells' combined levels; for example, if both spells are cast at level 3, a creature gains 12 Temporary Hit Points, or (3 + 3) × 2.
 
-### _Elegy of Emptiness_
+### _An Empty Shell_
 
 _Level 2 Conjuration/Rhythmancy (Bard)_
 
@@ -263,6 +263,17 @@ While reduced in this manner, the target's speed is halved; they have disadvanta
 
 The spell ends if you are unable to see the target.
 
+### _No Stone Unturned_
+
+_Level 2 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
+
+**Casting Time:** 1 minute or Ritual\
+**Range:** Self (20-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP, a magnifying glass worth 10+ GP)\
+**Duration:** Concentration, up to 10 minutes
+
+You perform a tune that disrupts any concealing magic in the vicinity. Until the spell ends, as a Magic action, you can attempt to reveal Invisible creatures and objects within your spell's area of effect. Make a spellcasting ability check. If there is a spell causing invisibility in your spell's area of effect, the DC equals 10 + the most powerful such spell's level in the area, or if the only invisibility present is caused by another magical effect, the DC is 15. On a success, all magical invisibility in the area of effect is dispelled, and this spell ends immediately. On a failure, or if there is no such magical invisibility nearby, your spell continues, but you gain no special insight into whether this outcome occurred due to failing the check or no viable Invisible creatures or objects being nearby.
+
 ### _Oath to Order_
 
 _Level 8 Abjuration/Rhythmancy (Bard)_
@@ -277,6 +288,21 @@ You call upon the spirits of ancient giants to grant you the ability to repel ma
 Until the spell ends, as a Magic action, you can target a creature or object within 30 feet of you and attempt to repel them. The target must succeed on a Strength saving throw or they are forcibly shoved a distance of your choice up to 100 feet away from you in a straight line and knocked Prone. If the target is a creature that is already Prone, they are additionally Stunned until the end of your next turn.
 
 Manipulating gravity and mass in this manner takes a physical toll on your body. Each time you attempt to repel a creature, at the end of your turn, you must succeed on a Constitution saving throw contested by your own Spell Save DC or suffer one level of Exhaustion.
+
+### _The Oncoming Storm_
+
+_Level 1 Evocation/Rhythmancy (Bard)_
+
+**Casting Time:** 1 minute\
+**Range:** 120 feet (1 mile if cast outdoors)\
+**Components:** V, S, M (a pebble or stone worn smooth by water used to forecast rainy weather; a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
+
+You summon a storm cloud that is 10 feet tall with a 20-foot radius, centered on a point you can see within range directly above you. The spell fails if you can't see a point in the air where the storm cloud could appear (for example, if you are in a room that can't accommodate the cloud).
+
+Until the spell ends, light rain falls in the area underneath the cloud. Invisible creatures under the cloud have disadvantage on attempts to hide as the rain patters on their bodies and reveals their locations as an outline of raindrops. The cloud moves with you.
+
+If you are outdoors in a light rain when you cast this spell, the spell affects the existing storm instead of creating a new cloud. Under such conditions, the storm becomes a heavy rain, causing the area to be lightly obscured, extinguishing open flames, and imposing disadvantage on Wisdom (Perception) checks that rely on sight or hearing. When the spell ends, the weather gradually returns to normal.
 
 ### _Peaceful Lullaby_
 
@@ -396,17 +422,6 @@ You stir slumbering creatures with rousing music. When you cast this spell, choo
 
 _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
 
-### _Song of Discovery_
-
-_Level 2 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
-
-**Casting Time:** 1 minute or Ritual\
-**Range:** Self (20-foot sphere)\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP, a magnifying glass worth 10+ GP)\
-**Duration:** Concentration, up to 10 minutes
-
-You perform a tune that disrupts any concealing magic in the vicinity. Until the spell ends, as a Magic action, you can attempt to reveal Invisible creatures and objects within your spell's area of effect. Make a spellcasting ability check. If there is a spell causing invisibility in your spell's area of effect, the DC equals 10 + the most powerful such spell's level in the area, or if the only invisibility present is caused by another magical effect, the DC is 15. On a success, all magical invisibility in the area of effect is dispelled, and this spell ends immediately. On a failure, or if there is no such magical invisibility nearby, your spell continues, but you gain no special insight into whether this outcome occurred due to failing the check or no viable Invisible creatures or objects being nearby.
-
 ### _Song of Passing_
 
 _Level 5 Illusion/Rhythmancy (Bard)_
@@ -423,21 +438,6 @@ While under the effects of this spell, the creature's senses are modified to con
 False memories are implanted in the creature's mind, such that they believe time and events have passed normally. Modified senses and memories don't necessarily affect how a creature behaves, but the creature will make normal efforts to proceed with activities that would make sense for the given time of day. Such activities might include leaving home to work a farm, closing a business for the night, departing for a formal occasion, preparing for bed, or any other time-specific activity.
 
 After the spell ends, the creature becomes aware that their senses and memories were altered by magic.
-
-### _Song of Storms_
-
-_Level 1 Evocation/Rhythmancy (Bard)_
-
-**Casting Time:** 1 minute\
-**Range:** 120 feet (1 mile if cast outdoors)\
-**Components:** V, S, M (a pebble or stone worn smooth by water used to forecast rainy weather; a Musical Instrument worth 1+ GP)\
-**Duration:** Concentration, up to 1 hour
-
-You summon a storm cloud that is 10 feet tall with a 20-foot radius, centered on a point you can see within range directly above you. The spell fails if you can't see a point in the air where the storm cloud could appear (for example, if you are in a room that can't accommodate the cloud).
-
-Until the spell ends, light rain falls in the area underneath the cloud. Invisible creatures under the cloud have disadvantage on attempts to hide as the rain patters on their bodies and reveals their locations as an outline of raindrops. The cloud moves with you.
-
-If you are outdoors in a light rain when you cast this spell, the spell affects the existing storm instead of creating a new cloud. Under such conditions, the storm becomes a heavy rain, causing the area to be lightly obscured, extinguishing open flames, and imposing disadvantage on Wisdom (Perception) checks that rely on sight or hearing. When the spell ends, the weather gradually returns to normal.
 
 ### _Song of Time_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -31,14 +31,14 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 3 | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Wind in My Sails](#the-wind-in-my-sails)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 4 | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | C |
-| 4 | _[The Sage of Earth's Calling](#the-sage-of-earths-calling)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
 | 4 | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | C |
+| 4 | _[The Sage of Earth's Calling](#the-sage-of-earths-calling)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
+| 4 | _[The Sage of Wind's Beckoning](#the-sage-of-winds-beckoning)_ | Evocation/Rhythmancy | Bard | M |
 | 4 | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | M |
 | 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | R, M |
-| 4 | _[The Sage of Wind's Beckoning](#the-sage-of-winds-beckoning)_ | Evocation/Rhythmancy | Bard | M |
+| 5 | _[Healing Balm](#healing-balm)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
-| 5 | _[Song of Healing](#song-of-healing)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Song of Passing](#song-of-passing)_ | Illusion/Rhythmancy | Bard | C |
 | 5 | _[Tune of Currents](#tune-of-currents)_ | Abjuration/Rhythmancy | Bard | M |
 | 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
@@ -176,6 +176,23 @@ _Evocation/Rhythmancy Cantrip (Bard)_
 You play a series of sharp tones evoking the shriek of a bird of prey, summoning a spectral bird to slash its talons at a creature of your choice that you can see within range. The bird can take whatever form you choose, then makes a melee spell attack against the target. On a hit, the bird deals 1d4 Piercing damage, and the target has disadvantage on Perception checks and Dexterity saving throws they make before the end of their next turn as the bird flies in their face to distract them. On a miss, or at the start of your next turn, the bird disappears, ending the spell.
 
 The spell creates more than one bird when you reach higher levels: two birds at 5th level, three birds at 11th level, and four birds at 17th level. You can direct the birds at the same target or at different ones. Make a separate attack roll for each bird. The spell ends at the start of your next turn or if all the birds disappear.
+
+### _Healing Balm_
+
+_Level 5 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
+
+**Casting Time:** 1 minute\
+**Range:** Self (30-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
+
+You channel healing energies through soothing music. All creatures that remain within 30 feet of you for the entire casting time, except for undead or constructs, regain 5d10 Hit Points and are cured of being Blinded, Deafened, and Diseased.
+
+The healing energy attempts to soothe the restless undead and allow them to move on from this world. Each undead creature within the spell's area of effect when it is finished casting must make a Wisdom saving throw (they can choose to fail this save). On a failed save, the creature is reduced to 0 Hit Points, their spirit moves on to the afterlife, and their remains are destroyed in a burst of radiant fire. Creatures that are immune to being Turned are not affected by this spell.
+
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 6 or higher, the healing increases by 1d10 for each additional spell level.
+
+When you cast this spell at level 7 or higher, the spell also ends the cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
 ### _The Lost is Found_
 
@@ -389,23 +406,6 @@ _Level 2 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 **Duration:** Concentration, up to 10 minutes
 
 You perform a tune that disrupts any concealing magic in the vicinity. Until the spell ends, as a Magic action, you can attempt to reveal Invisible creatures and objects within your spell's area of effect. Make a spellcasting ability check. If there is a spell causing invisibility in your spell's area of effect, the DC equals 10 + the most powerful such spell's level in the area, or if the only invisibility present is caused by another magical effect, the DC is 15. On a success, all magical invisibility in the area of effect is dispelled, and this spell ends immediately. On a failure, or if there is no such magical invisibility nearby, your spell continues, but you gain no special insight into whether this outcome occurred due to failing the check or no viable Invisible creatures or objects being nearby.
-
-### _Song of Healing_
-
-_Level 5 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
-
-**Casting Time:** 1 minute\
-**Range:** Self (30-foot sphere)\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
-**Duration:** Instantaneous
-
-You channel healing energies through soothing music. All creatures that remain within 30 feet of you for the entire casting time, except for undead or constructs, regain 5d10 Hit Points and are cured of being Blinded, Deafened, and Diseased.
-
-The healing energy attempts to soothe the restless undead and allow them to move on from this world. Each undead creature within the spell's area of effect when it is finished casting must make a Wisdom saving throw (they can choose to fail this save). On a failed save, the creature is reduced to 0 Hit Points, their spirit moves on to the afterlife, and their remains are destroyed in a burst of radiant fire. Creatures that are immune to being Turned are not affected by this spell.
-
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 6 or higher, the healing increases by 1d10 for each additional spell level.
-
-When you cast this spell at level 7 or higher, the spell also ends the cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
 ### _Song of Passing_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -332,9 +332,9 @@ _Enchantment/Rhythmancy Cantrip (Bard)_
 **Components:** V, M (a petal from a silent princess flower; a Musical Instrument worth 1+ GP)\
 **Duration:** 1 minute
 
-Playing this soothing melody historically indicated a connection to the royal family. Until this spell ends, you are considered to have Proficiency in all Charisma checks used to socially interact with creatures within range that heard you cast the spell.
+Playing this soothing melody historically indicated a connection to the royal family. Until this spell ends, you are considered to have temporary Expertise in all Charisma checks used to socially interact with creatures within range that heard you cast the spell.
 
-Your temporary Proficiency in these Charisma checks is further strengthened when you reach higher levels: your Proficiency Bonus is doubled at 5th level, tripled at 11th level, and quadrupled at 17th level.
+_**Cantrip Upgrade.**_ The spell's duration increases when you reach levels 5 (10 minutes), 11 (1 hour), and 17 (8 hours).
 
 ### _Royal Duet_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -31,11 +31,11 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 3 | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Wind in My Sails](#the-wind-in-my-sails)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 4 | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | C |
-| 4 | _[Earth God's Lyric](#earth-gods-lyric)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
+| 4 | _[The Sage of Earth's Calling](#the-sage-of-earths-calling)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
 | 4 | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | C |
 | 4 | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | M |
 | 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | R, M |
-| 4 | _[Wind God's Aria](#wind-gods-aria)_ | Evocation/Rhythmancy | Bard | M |
+| 4 | _[The Sage of Wind's Beckoning](#the-sage-of-winds-beckoning)_ | Evocation/Rhythmancy | Bard | M |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
 | 5 | _[Song of Healing](#song-of-healing)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
@@ -131,25 +131,6 @@ _Level 2 Evocation/Rhythmancy (Bard)_
 You and a partner play an uplifting Duet, targeting a shared location within range. When the spell finishes casting, any creatures that remained within the spells' area of effect for the entire casting and were able to hear the entire composition gain the benefits of a Short Rest. A creature must complete a Long Rest before they can gain this benefit from this song again.
 
 _**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 3 or higher, all creatures that gained the benefits of a Short Rest from this spell also gain a number of Temporary Hit Points equal to twice the spells' combined levels; for example, if both spells are cast at level 3, a creature gains 12 Temporary Hit Points, or (3 + 3) × 2.
-
-### _Earth God's Lyric_
-
-_Level 4 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
-
-**Casting Time:** 10 minutes\
-**Range:** Self\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP; a handful of soil from the Elemental Plane of Earth which the spell consumes)\
-**Duration:** 8 hours
-
-The notes you play resonate with the world under your feet, strengthening your bond to the earth. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
-
-Once you finish casting, until the spell ends, as long as you touch the ground, you cannot be unwillingly or forcibly removed from your location, as a magical gravitational pull holds you firm. This does not prevent you from being Grappled, but a creature Grappling you cannot separate you from the ground you stand on by any nonmagical means.
-
-Magical effects that would lift or relocate you as forced movement, such as the _levitate_ spell, end immediately and cannot target you, unless they are cast as spells at a higher level than you cast this spell. Magical effects that manipulate you into moving yourself, such as being Charmed and compelled to use your own movement, function normally.
-
-If a creature attempts to teleport or planeshift you against your will and they are not using a spell cast at a higher level than this spell, they must first succeed on a spellcasting ability check (or a Wisdom check if they do not have the ability to cast spells) contested by your Spell Save DC, or the teleport or planeshift fails to include you as a target.
-
-If you are moved, teleported, or planeshifted against your will, this spell's effects are suspended until the relocation is complete, after which you are once again tethered to whatever ground you are touching. If you are successfully separated from the ground against your will for 1 minute or longer, the spell ends.
 
 ### _Elegy of Emptiness_
 
@@ -349,6 +330,42 @@ You and a partner play an empowering Duet, targeting a shared location within ra
 
 _**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a d20 test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
 
+### _The Sage of Earth's Calling_
+
+_Level 4 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
+
+**Casting Time:** 10 minutes\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a handful of soil from the Elemental Plane of Earth which the spell consumes)\
+**Duration:** 8 hours
+
+The notes you play resonate with the world under your feet, strengthening your bond to the earth. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
+
+Once you finish casting, until the spell ends, as long as you touch the ground, you cannot be unwillingly or forcibly removed from your location, as a magical gravitational pull holds you firm. This does not prevent you from being Grappled, but a creature Grappling you cannot separate you from the ground you stand on by any nonmagical means.
+
+Magical effects that would lift or relocate you as forced movement, such as the _levitate_ spell, end immediately and cannot target you, unless they are cast as spells at a higher level than you cast this spell. Magical effects that manipulate you into moving yourself, such as being Charmed and compelled to use your own movement, function normally.
+
+If a creature attempts to teleport or planeshift you against your will and they are not using a spell cast at a higher level than this spell, they must first succeed on a spellcasting ability check (or a Wisdom check if they do not have the ability to cast spells) contested by your Spell Save DC, or the teleport or planeshift fails to include you as a target.
+
+If you are moved, teleported, or planeshifted against your will, this spell's effects are suspended until the relocation is complete, after which you are once again tethered to whatever ground you are touching. If you are successfully separated from the ground against your will for 1 minute or longer, the spell ends.
+
+### _The Sage of Wind's Beckoning_
+
+_Level 4 Evocation/Rhythmancy (Bard)_
+
+**Casting Time:** 10 minutes\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a vial of air from the Elemental Plane of Air which the spell consumes)\
+**Duration:** 8 hours
+
+The notes you play resonate with the air around you, lifting you upward and granting you free movement.
+
+Until the spell ends, you gain a flying speed equal to your movement speed, or if you already have a flying speed, it is increased by 30 feet. You hover in place when you are not flying.
+
+As long as you are not touching the ground, the air pulses around your body, granting you advantage on checks you make to resist being Grappled or to escape the Grappled condition. If you succeed on such a check, as a Reaction, you can immediately move up to half your flying speed away with a burst of wind, and the creature that was Grappling you must succeed on a Strength saving throw against your Spell Save DC or they are knocked Prone. This movement doesn't provoke opportunity attacks.
+
+If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
+
 ### _Sonata of Awakening_
 
 _Level 2 Abjuration/Rhythmancy (Bard)_
@@ -542,23 +559,6 @@ You create an image in the air 10 feet in front of you depicting your current ge
 For the duration of the spell, the image plays out the selected moment in real time. The image can display any location within 100 feet of where the spell was cast, switching focus as needed to depict the selected moment as fully as possible. You can see and hear through the image as if you were present at that point in time. If, at any point during the playback of the selected moment, a magical effect was present which blocked detection through Divination magic or being perceived through magical scrying sensors (such as with the _Nondetection_ spell), the image becomes unfocused and the sound becomes distorted until such a time that the magical effect ended or was not present.
 
 Any number of times before the spell ends, as a Magic action, you can spend an additional spell slot of any level to extend the spell's duration by a number of minutes equal to ten times the slot level.
-
-### _Wind God's Aria_
-
-_Level 4 Evocation/Rhythmancy (Bard)_
-
-**Casting Time:** 10 minutes\
-**Range:** Self\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP; a vial of air from the Elemental Plane of Air which the spell consumes)\
-**Duration:** 8 hours
-
-The notes you play resonate with the air around you, lifting you upward and granting you free movement.
-
-Until the spell ends, you gain a flying speed equal to your movement speed, or if you already have a flying speed, it is increased by 30 feet. You hover in place when you are not flying.
-
-As long as you are not touching the ground, the air pulses around your body, granting you advantage on checks you make to resist being Grappled or to escape the Grappled condition. If you succeed on such a check, as a Reaction, you can immediately move up to half your flying speed away with a burst of wind, and the creature that was Grappling you must succeed on a Strength saving throw against your Spell Save DC or they are knocked Prone. This movement doesn't provoke opportunity attacks.
-
-If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
 
 ### _The Wind in My Sails_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -21,7 +21,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 2 | _[An Empty Shell](#an-empty-shell)_ | Conjuration/Rhythmancy | Bard | — |
 | 2 | _[No Stone Unturned](#no-stone-unturned)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 2 | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | C |
-| 2 | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | C, M |
+| 2 | _[Stirring Sonata](#stirring-sonata)_ | Abjuration/Rhythmancy | Bard | C, M |
 | 2 | _[Souls Entwined](#souls-entwined)_ | Conjuration/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Cleansing Waves](#the-cleansing-waves)_ | Abjuration/Rhythmancy | Bard | C |
 | 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
@@ -409,19 +409,6 @@ As long as you are not touching the ground, the air pulses around your body, gra
 
 If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
 
-### _Sonata of Awakening_
-
-_Level 2 Abjuration/Rhythmancy (Bard)_
-
-**Casting Time:** Action\
-**Range:** 30 feet\
-**Components:** V, M (a Musical Instrument worth 1+ GP, a bell worth 5+ GP)\
-**Duration:** Concentration, up to 1 minute
-
-You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
-
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
-
 ### _Song of Time_
 
 _Level 1 Abjuration/Rhythmancy (Bard)_
@@ -462,19 +449,6 @@ If a creature casts a spell with a range of touch, their link can deliver the sp
 
 A linked creature can sever this magical link at any time, which ends the spell.
 
-### _Space Warp_
-
-_Level 4 Conjuration/Rhythmancy (Bard)_
-
-**Casting Time:** 10 minutes or Ritual\
-**Range:** 10 feet\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP; an object that was present when the target creature lost consciousness at the spell's destination which the spell consumes)\
-**Duration:** Instantaneous
-
-You play a prolonged melody, targeting a willing creature you can see within range and concentrating on a location where the target creature previously was Unconscious, including due to normal or magical sleep. Space then shifts around the target creature, causing them to teleport to a safe location on the outskirts or outside the entrance to your destination.
-
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 5 or higher, you can teleport an additional willing creature you can see within range to the destination per each additional spell level. When multiple creatures are targeted by this spell, you can choose a destination where any of the target creatures were Unconscious, and the casting time increases by 10 minutes for each additional creature you target beyond the first.
-
 ### _Soulful Croak_
 
 _Level 4 Necromancy/Rhythmancy (Bard)_
@@ -499,6 +473,32 @@ You attempt to influence the life energy of a corpse or undead creature you can 
 An undead creature targeted or raised by this spell must succeed on a Wisdom saving throw against your Spell Save DC or they are Charmed by you. On each of your turns, you can use a Bonus Action to mentally command any creature you Charmed with this spell within 60 feet of you; if you control any combination of creatures using this spell, _Animate Dead_, or similar spells, you can command any or all of them at the same time, issuing the same or different commands to each one. You decide what Action the creature will take and where they will move during their next turn, or you can issue a general command, such as to guard a particular chamber or corridor. If you issue no commands, the creature defends you and themself against hostile creatures and moves as needed to remain within at least 30 feet of you. Once given an order, the creature continues to follow it until the task is complete.
 
 On a successful save, or if the Charmed condition on the undead creature ends, the creature stops obeying any command you've given them and cannot be targeted by this spell again for the next 30 days.
+
+### _Space Warp_
+
+_Level 4 Conjuration/Rhythmancy (Bard)_
+
+**Casting Time:** 10 minutes or Ritual\
+**Range:** 10 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; an object that was present when the target creature lost consciousness at the spell's destination which the spell consumes)\
+**Duration:** Instantaneous
+
+You play a prolonged melody, targeting a willing creature you can see within range and concentrating on a location where the target creature previously was Unconscious, including due to normal or magical sleep. Space then shifts around the target creature, causing them to teleport to a safe location on the outskirts or outside the entrance to your destination.
+
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 5 or higher, you can teleport an additional willing creature you can see within range to the destination per each additional spell level. When multiple creatures are targeted by this spell, you can choose a destination where any of the target creatures were Unconscious, and the casting time increases by 10 minutes for each additional creature you target beyond the first.
+
+### _Stirring Sonata_
+
+_Level 2 Abjuration/Rhythmancy (Bard)_
+
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, M (a Musical Instrument worth 1+ GP, a bell worth 5+ GP)\
+**Duration:** Concentration, up to 1 minute
+
+You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
+
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
 
 ### _Summoning of the Scarecrow_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -130,7 +130,7 @@ _Level 2 Evocation/Rhythmancy (Bard)_
 
 You and a partner play an uplifting Duet, targeting a shared location within range. When the spell finishes casting, any creatures that remained within the spells' area of effect for the entire casting and were able to hear the entire composition gain the benefits of a Short Rest. A creature must complete a Long Rest before they can gain this benefit from this song again.
 
-**At Higher Levels.** When you and your partner both cast this spell at level 3 or higher, all creatures that gained the benefits of a Short Rest from this spell also gain a number of Temporary Hit Points equal to twice the spells' combined levels; for example, if both spells are cast at level 3, a creature gains 12 Temporary Hit Points, or (3 + 3) × 2.
+_**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 3 or higher, all creatures that gained the benefits of a Short Rest from this spell also gain a number of Temporary Hit Points equal to twice the spells' combined levels; for example, if both spells are cast at level 3, a creature gains 12 Temporary Hit Points, or (3 + 3) × 2.
 
 ### _Earth God's Lyric_
 
@@ -181,7 +181,7 @@ When you cast this spell and already have a companion, instead of making a new c
 
 If your companion is mistreated or harmed by you or any of your allies, or at their own discretion, they can choose to end their companionship to you, and you can similarly end this companionship at any time. If you already have a companion and target a new creature with this spell, the previous companionship ends. Otherwise, the companionship lasts until you or your companion dies.
 
-**At Higher Levels.** When you cast this spell to summon your companion using a Spell Slot of 2nd-level or higher, they gain a number of Temporary Hit Points equal to five times the Spell Slot level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your companion using a Spell Slot of 2nd-level or higher, they gain a number of Temporary Hit Points equal to five times the Spell Slot level.
 
 ### _The Hawk's Call_
 
@@ -207,7 +207,7 @@ _Level 1 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 
 You play a song to yourself that stirs old memories of a childhood friend. Until the spell ends, while you are traveling or exploring within the same environment you were in when casting the spell, you can't become lost except by magical means.
 
-**At Higher Levels.** When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to the spell slot level. Additionally, until the spell ends, if magical effects cause you to become lost, as a Magic action, you can attempt to identify a valid route to take for a specific intended destination on the same plane of existence as you. Make a spellcasting ability check contested by a DC equal to 10 + the other spell's level (or DC 15 if caused by another magical effect). On a success, the magical effects obfuscating your travel are suppressed for the duration of the spell, during which time the shortest and most direct route to your destination (but not necessarily the safest route) is drawn out as a spectral golden wire on the ground. On a failed check, the spell ends immediately.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to the spell slot level. Additionally, until the spell ends, if magical effects cause you to become lost, as a Magic action, you can attempt to identify a valid route to take for a specific intended destination on the same plane of existence as you. Make a spellcasting ability check contested by a DC equal to 10 + the other spell's level (or DC 15 if caused by another magical effect). On a success, the magical effects obfuscating your travel are suppressed for the duration of the spell, during which time the shortest and most direct route to your destination (but not necessarily the safest route) is drawn out as a spectral golden wire on the ground. On a failed check, the spell ends immediately.
 
 ### _Mambo Marino_
 
@@ -220,7 +220,7 @@ _Level 3 Conjuration/Rhythmancy (Bard)_
 
 You create a glowing 10-foot-diameter circle in the surface of a body of water you can see within range. The circle lasts for the spell's duration. At any time before the spell ends, as a Magic action, you can attempt to teleport to the circle, along with any willing creatures you can see within 30 feet of you. If the circle is more than 1 mile away, or if the circle's space is occupied or cannot accommodate all the creatures you specify, the teleportation fails. Otherwise, any creatures teleported by this spell instantly appear within the circle, and the spell ends.
 
-**At Higher Levels.** When you cast this spell at level 4 or higher, the diameter of the glowing circle you create increases by 10 feet per additional spell level, the duration increases (1 day at level 5, 1 week at level 7, or 1 month at level 9), and when you cast this spell at level 7 or higher, it lasts for the full duration. Additionally, if you cast this spell again before the duration ends, any circles that existed from your previous casting of the spell continue to function and inherit the new duration, unless you are more than 1 mile away from an existing circle, in which case all such circles disappear. While multiple circles exist, you can choose any of them as a destination when teleporting using this spell.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 4 or higher, the diameter of the glowing circle you create increases by 10 feet per additional spell level, the duration increases (1 day at level 5, 1 week at level 7, or 1 month at level 9), and when you cast this spell at level 7 or higher, it lasts for the full duration. Additionally, if you cast this spell again before the duration ends, any circles that existed from your previous casting of the spell continue to function and inherit the new duration, unless you are more than 1 mile away from an existing circle, in which case all such circles disappear. While multiple circles exist, you can choose any of them as a destination when teleporting using this spell.
 
 ### _Melody of Darkness_
 
@@ -235,7 +235,7 @@ You play a disturbing tune that drains the life energy of its listeners. All cre
 
 When you cast this spell, and on each of your turns for the spell's duration if you use a Magic action, all creatures cursed by this spell that can hear you take 5d6 Necrotic damage.
 
-**At Higher Levels.** When you cast this spell at level 6 or higher, creatures cursed by this spell take an additional 1d6 Necrotic damage for each additional spell level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 6 or higher, creatures cursed by this spell take an additional 1d6 Necrotic damage for each additional spell level.
 
 ### _Minute Minuet_
 
@@ -291,7 +291,7 @@ _Level 3 Enchantment/Rhythmancy (Bard)_
 
 You play a gentle melody in an attempt to lull a creature that can hear you in range. The target must succeed on a Wisdom saving throw or fall asleep and remain Unconscious until the spell ends, the target takes damage, or another creature takes an Action to wake them. Constructs and undead automatically succeed on this saving throw.
 
-**At Higher Levels.** When you cast this spell at level 4 or higher, for each spell slot above 3rd, the duration increases by 1 hour, and you can target an additional creature.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 4 or higher, for each spell slot above 3rd, the duration increases by 1 hour, and you can target an additional creature.
 
 ### _Repel the Dark_
 
@@ -306,7 +306,7 @@ You summon the cleansing power of sunlight, causing creatures of the night to co
 
 For the spell's duration, you shed bright light in a 15-foot radius and dim light for an additional 15 feet. This light is sunlight.
 
-**At Higher Levels.** When you cast this spell at level 3 or higher, any creatures forced to make a Constitution saving throw by this spell make their saving throw with Disadvantage if their Challenge Rating is less than the spell's level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, any creatures forced to make a Constitution saving throw by this spell make their saving throw with Disadvantage if their Challenge Rating is less than the spell's level.
 
 ### _The River Devil's Lament_
 
@@ -321,7 +321,7 @@ You recite the tale of an ancient hero who drove away a great evil, in order to 
 
 Each time the creature takes damage (except from this spell's effects), they can repeat their saving throw, ending the cursed condition on a success. You can additionally choose to end the curse by using a Magic action to dismiss the spell.
 
-**At Higher Levels.** When you cast this spell at level 7 or higher, the duration increases to 1 day at level 7, 30 days at level 8, or 1 year at level 9, and the Psychic damage dealt when the creature can see you increases by 1d10 for each additional spell level. Additionally, when you cast this spell at level 8 or higher, the creature can no longer repeat their saving throws when they take damage.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 7 or higher, the duration increases to 1 day at level 7, 30 days at level 8, or 1 year at level 9, and the Psychic damage dealt when the creature can see you increases by 1d10 for each additional spell level. Additionally, when you cast this spell at level 8 or higher, the creature can no longer repeat their saving throws when they take damage.
 
 ### _The Royal Decree_
 
@@ -347,7 +347,7 @@ _Level 3 Evocation/Rhythmancy (Bard)_
 
 You and a partner play an empowering Duet, targeting a shared location within range. When the spell finishes casting, any creatures who remained within the spells' area of effect for the entire casting and were able to hear the entire composition have Advantage on a single d20 test of their choice that they make within the spells' duration.
 
-**At Higher Levels.** When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a d20 test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
+_**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a d20 test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
 
 ### _Sonata of Awakening_
 
@@ -360,7 +360,7 @@ _Level 2 Abjuration/Rhythmancy (Bard)_
 
 You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
 
-**At Higher Levels.** When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
 
 ### _Song of Discovery_
 
@@ -386,7 +386,7 @@ You channel healing energies through soothing music. All creatures that remain w
 
 The healing energy attempts to soothe the restless undead and allow them to move on from this world. Each undead creature within the spell's area of effect when it is finished casting must make a Wisdom saving throw (they can choose to fail this save). On a failed save, the creature is reduced to 0 Hit Points, their spirit moves on to the afterlife, and their remains are destroyed in a burst of radiant fire. Creatures that are immune to being Turned are not affected by this spell.
 
-**At Higher Levels.** When you cast this spell at level 6 or higher, the healing increases by 1d10 for each additional spell level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 6 or higher, the healing increases by 1d10 for each additional spell level.
 
 When you cast this spell at level 7 or higher, the spell also ends the cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
@@ -433,7 +433,7 @@ _Level 1 Abjuration/Rhythmancy (Bard)_
 
 You adjust the flow of time around you, granting you the ability to correct a recent mistake. Until this spell ends, if you fail on an attack roll, ability check, or saving throw, as a Reaction, you can immediately roll a d20 and take the greater of the two results. The first time you fail a check using this spell effect, the spell ends.
 
-**At Higher Levels.** When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to half the spell's level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to half the spell's level.
 
 If desired, you can alter the performance of the Song of Time to a related composition to create one of the following effects, which replace the spell's normal 1st-level effects:
 
@@ -456,7 +456,7 @@ _Level 4 Conjuration/Rhythmancy (Bard)_
 
 You play a prolonged melody, targeting a willing creature you can see within range and concentrating on a location where the target creature previously was Unconscious, including due to normal or magical sleep. Space then shifts around the target creature, causing them to teleport to a safe location on the outskirts or outside the entrance to your destination.
 
-**At Higher Levels.** When you cast this spell at level 5 or higher, you can teleport an additional willing creature you can see within range to the destination per each additional spell level. When multiple creatures are targeted by this spell, you can choose a destination where any of the target creatures were Unconscious, and the casting time increases by 10 minutes for each additional creature you target beyond the first.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 5 or higher, you can teleport an additional willing creature you can see within range to the destination per each additional spell level. When multiple creatures are targeted by this spell, you can choose a destination where any of the target creatures were Unconscious, and the casting time increases by 10 minutes for each additional creature you target beyond the first.
 
 ### _Soulful Croak_
 
@@ -573,7 +573,7 @@ You create an unnatural strong wind at your back, overriding any existing wind d
 
 While concentrating on this spell, as a Magic action, you can attempt to channel this magical wind to carry yourself and jump up to your jumping distance without using any movement. Make a Strength (Athletics) or Dexterity (Acrobatics) check and add your spellcasting ability modifier, contested by a DC equal to one-sixth the number of feet you are attempting to jump (minimum DC 10, maximum DC 25). On a success, if there is level ground with enough space to accommodate you, you land safely at your intended destination. If there is insufficient space to land safely at your intended jump distance, you fall short in a safe space of your choice. On a failure, or if there is no eligible space to land safely in your path, your jump falls short a number of feet equal to your Athletics or Acrobatics check, and you fall Prone. Whether you succeed or fail, the spell ends immediately.
 
-**At Higher Levels.** When you cast this spell at level 4 or higher, your jumping distance is multiplied by the spell level number. For example, casting this spell at level 4 would cause your jumping distance to be quadrupled.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 4 or higher, your jumping distance is multiplied by the spell level number. For example, casting this spell at level 4 would cause your jumping distance to be quadrupled.
 
 ---
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -17,12 +17,12 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 1 | _[The Oncoming Storm](#the-oncoming-storm)_ | Evocation/Rhythmancy | Bard | Concentration |
 | 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 1 | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard | — |
-| 2 | _[Command Melody](#command-melody)_ | Conjuration/Rhythmancy | Bard | C, R, M |
 | 2 | _[Duet of Restoration](#duet-of-restoration)_ | Evocation/Rhythmancy | Bard | D |
 | 2 | _[An Empty Shell](#an-empty-shell)_ | Conjuration/Rhythmancy | Bard | — |
 | 2 | _[No Stone Unturned](#no-stone-unturned)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 2 | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | C |
 | 2 | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | C, M |
+| 2 | _[Souls Entwined](#souls-entwined)_ | Conjuration/Rhythmancy | Bard | C, R, M |
 | 3 | _[The Cleansing Waves](#the-cleansing-waves)_ | Abjuration/Rhythmancy | Bard | C |
 | 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
 | 3 | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | C |
@@ -103,23 +103,6 @@ _Level 3 Abjuration/Rhythmancy (Bard)_
 **Duration:** Concentration, up to 1 minute
 
 Until the spell ends, an aura of spectral water and healing energy surrounds you in a 10-foot Emanation. While in the aura, creatures are immune to the effects of magical silence, such as the _Silence_ spell, and the effects of magical Darkness, such as the _Darkness_ spell. Such creatures can speak, hear, and see normally, and they are able to use Verbal components to cast spells. The aura does not dispel any spells or magical effects causing silence or Darkness, but if the aura is contained completely within an area of magical silence or magical Darkness, any such magical sound or light stops at the edge of the sphere and cannot travel in or out of it.
-
-### _Command Melody_
-
-_Level 2 Conjuration/Rhythmancy (Bard)_
-
-**Casting Time:** 1 minute or Ritual\
-**Range:** 10 feet\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP; objects belonging to you and the target creature worth a total of 1+ SP which the spell consumes)\
-**Duration:** Concentration, up to 1 hour
-
-You conduct a brief tune for a willing creature within range that can hear you. Until the spell ends, while the target is on the same plane of existence as you, both you and the target are magically linked to each other. A creature can only be linked to one other creature at a time using this spell.
-
-A creature can communicate with their link telepathically. Additionally, as a Magic action, a creature can see through their link's eyes and hear what they hear until the start of the creature's next turn, gaining the benefits of any special senses that their link has, but they are Blinded and Deafened to their own surroundings.
-
-If a creature casts a spell with a range of touch, their link can deliver the spell as if the link had cast the spell. The caster's link must be within 100 feet of them, and the link must choose to use their Reaction to deliver the spell when cast. If the spell requires an attack roll, the casting creature uses their attack modifier for the roll.
-
-A linked creature can sever this magical link at any time, which ends the spell.
 
 ### _The Curse, Reversed_
 
@@ -461,6 +444,23 @@ If desired, you can alter the performance of the Song of Time to a related compo
 #### _Inverted Song of Time_
 
 **Inverted Song of Time (5th-level or higher).** By playing the Song of Time in reverse, you anchor yourself to a moment in time, allowing yourself to complete more tasks in a short time period. Until the spell ends, your speed is doubled, you gain +2 to your AC, you have advantage on Dexterity saving throws, and you gain an additional Action on each of your turns.
+
+### _Souls Entwined_
+
+_Level 2 Conjuration/Rhythmancy (Bard)_
+
+**Casting Time:** 1 minute or Ritual\
+**Range:** 10 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; objects belonging to you and the target creature worth a total of 1+ SP which the spell consumes)\
+**Duration:** Concentration, up to 1 hour
+
+You conduct a brief tune for a willing creature within range that can hear you. Until the spell ends, while the target is on the same plane of existence as you, both you and the target are magically linked to each other. A creature can only be linked to one other creature at a time using this spell.
+
+A creature can communicate with their link telepathically. Additionally, as a Magic action, a creature can see through their link's eyes and hear what they hear until the start of the creature's next turn, gaining the benefits of any special senses that their link has, but they are Blinded and Deafened to their own surroundings.
+
+If a creature casts a spell with a range of touch, their link can deliver the spell as if the link had cast the spell. The caster's link must be within 100 feet of them, and the link must choose to use their Reaction to deliver the spell when cast. If the spell requires an attack roll, the casting creature uses their attack modifier for the roll.
+
+A linked creature can sever this magical link at any time, which ends the spell.
 
 ### _Space Warp_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -6,8 +6,8 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 
 ##### Rhythmancy Spells
 
-| Level | Spell | School | Class | Tags |
-|:-----:|:------|:-------|:------|:-----|
+| Level | Spell | School | Class | Special |
+|:-----:|:------|:-------|:------|:--------|
 | cantrip | _[Ballad of the Dreamer](#ballad-of-the-dreamer)_ | Abjuration/Rhythmancy | Bard | — |
 | cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard | — |
 | cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | — |

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -29,7 +29,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 3 | _[Royal Duet](#royal-duet)_ | Evocation/Rhythmancy | Bard | D |
 | 3 | _[Song of Double Time](#song-of-double-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 3 | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | C, R, M |
-| 3 | _[Wind's Requiem](#winds-requiem)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
+| 3 | _[The Wind in My Sails](#the-wind-in-my-sails)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
 | 4 | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | C |
 | 4 | _[Earth God's Lyric](#earth-gods-lyric)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
 | 4 | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | C |
@@ -560,7 +560,7 @@ As long as you are not touching the ground, the air pulses around your body, gra
 
 If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
 
-### _Wind's Requiem_
+### _The Wind in My Sails_
 
 _Level 3 Conjuration/Rhythmancy (Bard, Ranger (Wild Composer))_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -1,6 +1,6 @@
 # Chapter 5: Rhythmancy Spells
 
-This section contains new spells developed through the musical study of rhythmancy. These spells are available to the bard class, as well as other spellcasting classes with the Dungeon Master's consent (see "Rhythmancy Spells for Other Classes"). The **Rhythmancy Spells** table lists the new spells, ordering them by level. The table also notes the schools of magic of a spell, whether it bears any tags, and which classes have access to it.
+This section contains new spells developed through the musical study of rhythmancy. These spells are available to the Bard class, as well as other spellcasting classes with the Dungeon Master's consent (see "Rhythmancy Spells for Other Classes"). The **Rhythmancy Spells** table lists the new spells, organized by spell level and then alphabetized, and each spell's schools of magic are listed along with which classes have access to it. In the Special column, _C_ means the spell requires Concentration, _R_ means it's a Ritual, _M_ means it requires a specific Material component (in addition to the normal requirement of a Musical Instrument worth 1+ GP), and _D_ means it's a Duet.
 
 In some cases, multiple rhythmancy spells are learned as a single song, existing as alternate versions of a composition and applying their unique effects only when cast at a higher level. Such spells are labeled with shared footnote markers on this list for reference; see the description for the lowest-level version of the spell for all the other spells' effects.
 
@@ -8,55 +8,56 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 
 | Level | Spell | School | Class | Tags |
 |:-----:|:------|:-------|:------|:-----|
-| cantrip | _[Ballad of the Dreamer](#ballad-of-the-dreamer)_ | Abjuration/Rhythmancy | Bard | |
-| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard | |
-| cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | |
-| 1st | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | |
-| 1st | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | Concentration, Ritual |
-| 1st | _[Song of Storms](#song-of-storms)_ | Evocation/Rhythmancy | Bard | Concentration |
-| 1st | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | |
-| 1st | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard | |
-| 2nd | _[Command Melody](#command-melody)_ | Conjuration/Rhythmancy | Bard | Concentration, Ritual |
-| 2nd | _[Duet of Restoration](#duet-of-restoration)_ | Evocation/Rhythmancy | Bard | Duet |
-| 2nd | _[Elegy of Emptiness](#elegy-of-emptiness)_ | Conjuration/Rhythmancy | Bard | |
-| 2nd | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | Concentration |
-| 2nd | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | Concentration |
-| 2nd | _[Song of Discovery](#song-of-discovery)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | Concentration, Ritual |
-| 3rd | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | Concentration, Ritual |
-| 3rd | _[New Wave Bossa Nova](#new-wave-bossa-nova)_ | Abjuration/Rhythmancy | Bard | Concentration |
-| 3rd | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | Concentration |
-| 3rd | _[Royal Duet](#royal-duet)_ | Evocation/Rhythmancy | Bard | Duet |
-| 3rd | _[Song of Double Time](#song-of-double-time)_ | Abjuration/Rhythmancy | Bard | |
-| 3rd | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | Concentration, Ritual |
-| 3rd | _[Wind's Requiem](#winds-requiem)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | Concentration, Ritual |
-| 4th | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | Concentration |
-| 4th | _[Earth God's Lyric](#earth-gods-lyric)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | |
-| 4th | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | Concentration |
-| 4th | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | |
-| 4th | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | Ritual |
-| 4th | _[Wind God's Aria](#wind-gods-aria)_ | Evocation/Rhythmancy | Bard | |
-| 5th | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | |
-| 5th | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | Concentration |
-| 5th | _[Song of Healing](#song-of-healing)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | |
-| 5th | _[Song of Passing](#song-of-passing)_ | Illusion/Rhythmancy | Bard | Concentration |
-| 5th | _[Tune of Currents](#tune-of-currents)_ | Abjuration/Rhythmancy | Bard | |
-| 6th | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | |
-| 7th | _[Tune of Ages](#tune-of-ages)_ | Conjuration/Rhythmancy | Bard | |
-| 8th | _[Ballad of Gales](#ballad-of-gales)_ | Conjuration/Rhythmancy | Bard | |
-| 8th | _[Oath to Order](#oath-to-order)_ | Abjuration/Rhythmancy | Bard | |
+| cantrip | _[Ballad of the Dreamer](#ballad-of-the-dreamer)_ | Abjuration/Rhythmancy | Bard | — |
+| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard | — |
+| cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | — |
+| 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard | |
+| 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | — |
+| 1 | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R |
+| 1 | _[Song of Storms](#song-of-storms)_ | Evocation/Rhythmancy | Bard | Concentration |
+| 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
+| 1 | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard | — |
+| 2 | _[Command Melody](#command-melody)_ | Conjuration/Rhythmancy | Bard | C, R, M |
+| 2 | _[Duet of Restoration](#duet-of-restoration)_ | Evocation/Rhythmancy | Bard | D |
+| 2 | _[Elegy of Emptiness](#elegy-of-emptiness)_ | Conjuration/Rhythmancy | Bard | — |
+| 2 | _[Repel the Dark](#repel-the-dark)_ | Evocation/Rhythmancy | Bard | C |
+| 2 | _[Sonata of Awakening](#sonata-of-awakening)_ | Abjuration/Rhythmancy | Bard | C, M |
+| 2 | _[Song of Discovery](#song-of-discovery)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
+| 3 | _[Mambo Marino](#mambo-marino)_ | Conjuration/Rhythmancy | Bard | C, R |
+| 3 | _[New Wave Bossa Nova](#new-wave-bossa-nova)_ | Abjuration/Rhythmancy | Bard | C |
+| 3 | _[Peaceful Lullaby](#peaceful-lullaby)_ | Enchantment/Rhythmancy | Bard | C |
+| 3 | _[Royal Duet](#royal-duet)_ | Evocation/Rhythmancy | Bard | D |
+| 3 | _[Song of Double Time](#song-of-double-time)_ | Abjuration/Rhythmancy | Bard | — |
+| 3 | _[Tune of Echoes](#tune-of-echoes)_ | Divination/Rhythmancy | Bard | C, R, M |
+| 3 | _[Wind's Requiem](#winds-requiem)_ | Conjuration/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
+| 4 | _[Death's Departure](#deaths-departure)_ | Abjuration/Rhythmancy | Bard | C |
+| 4 | _[Earth God's Lyric](#earth-gods-lyric)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
+| 4 | _[Minute Minuet](#minute-minuet)_ | Transmutation/Rhythmancy | Bard | C |
+| 4 | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | M |
+| 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | R, M |
+| 4 | _[Wind God's Aria](#wind-gods-aria)_ | Evocation/Rhythmancy | Bard | M |
+| 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
+| 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
+| 5 | _[Song of Healing](#song-of-healing)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
+| 5 | _[Song of Passing](#song-of-passing)_ | Illusion/Rhythmancy | Bard | C |
+| 5 | _[Tune of Currents](#tune-of-currents)_ | Abjuration/Rhythmancy | Bard | M |
+| 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
+| 7 | _[Tune of Ages](#tune-of-ages)_ | Conjuration/Rhythmancy | Bard | M |
+| 8 | _[Ballad of Gales](#ballad-of-gales)_ | Conjuration/Rhythmancy | Bard | M |
+| 8 | _[Oath to Order](#oath-to-order)_ | Abjuration/Rhythmancy | Bard | M |
 
 ## Spell Descriptions
 
 The spells are presented in alphabetical order.
 
-### Ballad of Gales
+### _Ballad of Gales_
 
-_Level 8 Conjuration/Rhythmancy_ (Bard)
+_Level 8 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** Touch
-- **Components:** V, S, M (an instrument worth at least 1 gp, a vehicle that you are currently occupying worth at least 10 gp)
-- **Duration:** 1 round
+**Casting Time:** 1 minute\
+**Range:** Touch\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP, a vehicle that you are currently occupying worth 10+ GP)\
+**Duration:** 1 round
 
 If you occupy a vehicle the entire time you cast this spell, you summon a shimmering portal surrounding the vehicle, and a second portal of the same size at another location on the same plane of existence. If the vehicle is a ship in water, the portals manifest as powerful cyclones in the waters at both locations. The portals remain open until the end of your next turn. Any creature or object that enters one portal, including you and all other creatures and objects aboard the target vehicle, instantly appears within 5 feet of the other portal, or in the nearest unoccupied space if that space is occupied. After the spell ends, the portals fade away.
 
@@ -64,25 +65,25 @@ You must have seen or been physically present at the destination at least once b
 
 The act of teleporting the vehicle deals it 8d6 Force damage, ignoring damage thresholds.
 
-### Ballad of the Dreamer
+### _Ballad of the Dreamer_
 
-_Abjuration/Rhythmancy Cantrip_ (Bard)
+_Abjuration/Rhythmancy Cantrip (Bard)_
 
-- **Casting Time:** Action
-- **Range:** Self
-- **Components:** V, M (a seagull's feather; an instrument worth at least 1 gp)
-- **Duration:** 10 minutes
+**Casting Time:** Action\
+**Range:** Self\
+**Components:** V, M (a seagull's feather; a Musical Instrument worth 1+ GP)\
+**Duration:** 10 minutes
 
 You play a soothing melody that conjures strange memories of a dream-like world. Until the spell ends, magic can't put you to sleep.
 
-### Command Melody
+### _Command Melody_
 
-_Level 2 Conjuration/Rhythmancy (Ritual)_ (Bard)
+_Level 2 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 10 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp; objects belonging to you and the target creature worth a total of at least 1 sp which the spell consumes)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** 1 minute or Ritual\
+**Range:** 10 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; objects belonging to you and the target creature worth a total of 1+ SP which the spell consumes)\
+**Duration:** Concentration, up to 1 hour
 
 You conduct a brief tune for a willing creature within range that can hear you. Until the spell ends, while the target is on the same plane of existence as you, both you and the target are magically linked to each other. A creature can only be linked to one other creature at a time using this spell.
 
@@ -92,40 +93,53 @@ If a creature casts a spell with a range of touch, their link can deliver the sp
 
 A linked creature can sever this magical link at any time, which ends the spell.
 
-### Death's Departure
+### _The Curse, Reversed_
 
-_Level 4 Abjuration/Rhythmancy_ (Bard)
+_Level 1 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** Self (30-foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 minute
+**Casting Time:** 1 minute\
+**Range:** Touch\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
+
+You touch a creature that was cursed within the last hour. One eligible curse affecting the target ends. This spell can't end a curse placed using a spell of level 2 or higher, or by a creature of CR 2 or higher.
+
+_**Using a Higher-Level Spell Slot.**_ You automatically end an eligible curse affecting the target if it was placed by either a spell of a level equal to or less than, or a creature of CR equal to or less than, the level of the spell slot you use.
+
+### _Death's Departure_
+
+_Level 4 Abjuration/Rhythmancy (Bard)_
+
+**Casting Time:** Action\
+**Range:** Self (30-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 minute
 
 You perform a melody that repels the walking dead from your immediate vicinity. When an undead creature enters the spell's area of effect for the first time on a turn or starts their turn there, they must make a Wisdom saving throw. On a failed save, a creature is Frightened of you for the duration of the spell, or until they leave the spell's area of effect. Creatures that are normally immune to being Frightened have advantage on this saving throw but are otherwise not immune to the Frightened condition caused by this spell. Creatures that are immune to being Turned are not affected by this spell.
 
 On each of your turns, you must use a Magic action to continue playing the song. The spell ends if you don't take this Magic action by the end of your turn.
 
-### Duet of Restoration
+### _Duet of Restoration_
 
-_Level 2 Evocation/Rhythmancy (Duet)_ (Bard)
+_Level 2 Evocation/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 10 feet (30-foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Instantaneous
+**Casting Time:** 1 minute Duet\
+**Range:** 10 feet (30-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
 
 You and a partner play an uplifting Duet, targeting a shared location within range. When the spell finishes casting, any creatures that remained within the spells' area of effect for the entire casting and were able to hear the entire composition gain the benefits of a Short Rest. A creature must complete a Long Rest before they can gain this benefit from this song again.
 
 **At Higher Levels.** When you and your partner both cast this spell at level 3 or higher, all creatures that gained the benefits of a Short Rest from this spell also gain a number of Temporary Hit Points equal to twice the spells' combined levels; for example, if both spells are cast at level 3, a creature gains 12 Temporary Hit Points, or (3 + 3) × 2.
 
-### Earth God's Lyric
+### _Earth God's Lyric_
 
-_Level 4 Evocation/Rhythmancy_ (Bard, Ranger (Wild Composer))
+_Level 4 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
 
-- **Casting Time:** 10 minutes
-- **Range:** Self
-- **Components:** V, S, M (an instrument worth at least 1 gp; a handful of soil from the Elemental Plane of Earth which the spell consumes)
-- **Duration:** 8 hours
+**Casting Time:** 10 minutes\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a handful of soil from the Elemental Plane of Earth which the spell consumes)\
+**Duration:** 8 hours
 
 The notes you play resonate with the world under your feet, strengthening your bond to the earth. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
 
@@ -137,27 +151,27 @@ If a creature attempts to teleport or planeshift you against your will and they 
 
 If you are moved, teleported, or planeshifted against your will, this spell's effects are suspended until the relocation is complete, after which you are once again tethered to whatever ground you are touching. If you are successfully separated from the ground against your will for 1 minute or longer, the spell ends.
 
-### Elegy of Emptiness
+### _Elegy of Emptiness_
 
-_Level 2 Conjuration/Rhythmancy_ (Bard)
+_Level 2 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 5 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Until dispelled
+**Casting Time:** 1 minute\
+**Range:** 5 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Until dispelled
 
 You create a duplicate of your body in the form of an empty shell in an unoccupied space within range. This shell is an inanimate object exactly your height, weight, physical size, and body shape. Its appearance is superficially similar to that of your body and facial appearance, as well as any clothing you were wearing and any equipment you were carrying when casting the spell, though this false equipment is part of the shell's form and is not removable. The shell appears to be made of a hard stone-like material when touched. Its false body is fixed in a rigid standing position with its appendages resting at its sides. The shell is indestructible.
 
 A shell based on your form vanishes the next time you cast this spell, unless your body is in a different form when casting the spell (such as being shapeshifted or polymorphed), in which case a unique shell is created based on your different form. If you create a new shell and a number of shells up to your Proficiency Bonus already exist, the oldest shell vanishes.
 
-### Equine Tribute
+### _Equine Tribute_
 
-_Level 1 Conjuration/Rhythmancy_ (Bard)
+_Level 1 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 30 feet
-- **Components:** V, S, M (a sprig of horse grass; an instrument worth at least 1 gp)
-- **Duration:** Instantaneous
+**Casting Time:** 1 minute\
+**Range:** 30 feet\
+**Components:** V, S, M (a sprig of horse grass; a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
 
 You recant the tale of a great hero's beloved horse companion to endear yourself to a horse with an Intelligence score less than 10 within range; at the Dungeon Master's discretion, you can target a creature other than a horse, as long as they are at least one size category larger than you and have an appropriate anatomy to serve as your mount. If the target is willing, is able to hear you, and remains within range for the entire casting of the spell, they are considered to be your companion.
 
@@ -169,68 +183,68 @@ If your companion is mistreated or harmed by you or any of your allies, or at th
 
 **At Higher Levels.** When you cast this spell to summon your companion using a Spell Slot of 2nd-level or higher, they gain a number of Temporary Hit Points equal to five times the Spell Slot level.
 
-### The Hawk's Call
+### _The Hawk's Call_
 
-_Evocation/Rhythmancy Cantrip_ (Bard)
+_Evocation/Rhythmancy Cantrip (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, S, M (a sprig of hawk grass; an instrument worth at least 1 gp)
-- **Duration:** 1 round
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a sprig of hawk grass; a Musical Instrument worth 1+ GP)\
+**Duration:** 1 round
 
 You play a series of sharp tones evoking the shriek of a bird of prey, summoning a spectral bird to slash its talons at a creature of your choice that you can see within range. The bird can take whatever form you choose, then makes a melee spell attack against the target. On a hit, the bird deals 1d4 Piercing damage, and the target has disadvantage on Perception checks and Dexterity saving throws they make before the end of their next turn as the bird flies in their face to distract them. On a miss, or at the start of your next turn, the bird disappears, ending the spell.
 
 The spell creates more than one bird when you reach higher levels: two birds at 5th level, three birds at 11th level, and four birds at 17th level. You can direct the birds at the same target or at different ones. Make a separate attack roll for each bird. The spell ends at the start of your next turn or if all the birds disappear.
 
-### The Lost is Found
+### _The Lost is Found_
 
-_Level 1 Divination/Rhythmancy (Ritual)_ (Bard, Ranger (Wild Composer))
+_Level 1 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 
-- **Casting Time:** 1 minute
-- **Range:** Self
-- **Components:** V, S, M (a branch or leaf from a tree you've climbed; an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** 1 minute or Ritual\
+**Range:** Self\
+**Components:** V, S, M (a branch or leaf from a tree you've climbed; a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
 
 You play a song to yourself that stirs old memories of a childhood friend. Until the spell ends, while you are traveling or exploring within the same environment you were in when casting the spell, you can't become lost except by magical means.
 
 **At Higher Levels.** When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to the spell slot level. Additionally, until the spell ends, if magical effects cause you to become lost, as a Magic action, you can attempt to identify a valid route to take for a specific intended destination on the same plane of existence as you. Make a spellcasting ability check contested by a DC equal to 10 + the other spell's level (or DC 15 if caused by another magical effect). On a success, the magical effects obfuscating your travel are suppressed for the duration of the spell, during which time the shortest and most direct route to your destination (but not necessarily the safest route) is drawn out as a spectral golden wire on the ground. On a failed check, the spell ends immediately.
 
-### Mambo Marino
+### _Mambo Marino_
 
-_Level 3 Conjuration/Rhythmancy (Ritual)_ (Bard)
+_Level 3 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 10 feet
-- **Components:** V, M (a mola scale; an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 8 hours
+**Casting Time:** 1 minute or Ritual\
+**Range:** 10 feet\
+**Components:** V, M (a mola scale; a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 8 hours
 
 You create a glowing 10-foot-diameter circle in the surface of a body of water you can see within range. The circle lasts for the spell's duration. At any time before the spell ends, as a Magic action, you can attempt to teleport to the circle, along with any willing creatures you can see within 30 feet of you. If the circle is more than 1 mile away, or if the circle's space is occupied or cannot accommodate all the creatures you specify, the teleportation fails. Otherwise, any creatures teleported by this spell instantly appear within the circle, and the spell ends.
 
 **At Higher Levels.** When you cast this spell at level 4 or higher, the diameter of the glowing circle you create increases by 10 feet per additional spell level, the duration increases (1 day at level 5, 1 week at level 7, or 1 month at level 9), and when you cast this spell at level 7 or higher, it lasts for the full duration. Additionally, if you cast this spell again before the duration ends, any circles that existed from your previous casting of the spell continue to function and inherit the new duration, unless you are more than 1 mile away from an existing circle, in which case all such circles disappear. While multiple circles exist, you can choose any of them as a destination when teleporting using this spell.
 
-### Melody of Darkness
+### _Melody of Darkness_
 
-_Level 5 Necromancy/Rhythmancy_ (Bard)
+_Level 5 Necromancy/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** Self (30 foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 minute
+**Casting Time:** Action\
+**Range:** Self (30 foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 minute
 
-You play a disturbing tune that drains the life energy of its listeners. All creatures other than yourself within 30 feet of you that can hear you must succeed on a Wisdom saving throw or become Cursed for the duration of the spell. This spell has no effect on undead or constructs.
+You play a disturbing tune that drains the life energy of its listeners. All creatures other than yourself within 30 feet of you that can hear you must succeed on a Wisdom saving throw or become cursed for the duration of the spell. This spell has no effect on undead or constructs.
 
-When you cast this spell, and on each of your turns for the spell's duration if you use a Magic action, all creatures Cursed by this spell that can hear you take 5d6 Necrotic damage.
+When you cast this spell, and on each of your turns for the spell's duration if you use a Magic action, all creatures cursed by this spell that can hear you take 5d6 Necrotic damage.
 
-**At Higher Levels.** When you cast this spell at level 6 or higher, creatures Cursed by this spell take an additional 1d6 Necrotic damage for each additional spell level.
+**At Higher Levels.** When you cast this spell at level 6 or higher, creatures cursed by this spell take an additional 1d6 Necrotic damage for each additional spell level.
 
-### Minute Minuet
+### _Minute Minuet_
 
-_Level 4 Transmutation/Rhythmancy_ (Bard)
+_Level 4 Transmutation/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 10 minutes
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 10 minutes
 
 You attempt to diminish a creature you can see within range that can hear you. The target makes a Constitution saving throw. On a failed save, until the spell ends, the target's size is reduced to one-fourth of normal in all dimensions, their weight is reduced to one-sixty-fourth of normal, and their size decreases by two categories (e.g. from Large to Small, minimum Tiny). On a successful save, the spell ends.
 
@@ -240,25 +254,25 @@ While reduced in this manner, the target's speed is halved; they have disadvanta
 
 The spell ends if you are unable to see the target.
 
-### New Wave Bossa Nova
+### _New Wave Bossa Nova_
 
-_Level 3 Abjuration/Rhythmancy_ (Bard)
+_Level 3 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** Self (10-foot sphere)
-- **Components:** V (functions even if you are in an area affected by magical silence), S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 minute
+**Casting Time:** Action\
+**Range:** Self (10-foot sphere)\
+**Components:** V (functions even if you are in an area affected by magical silence), S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 minute
 
 Until the spell ends, you create a sphere of healing energy that negates the effects of magical silence, such as the _Silence_ spell, and the effects of magical darkness, such as the _Darkness_ spell. The sphere moves with you. Creatures within this sphere hear normally in magical silence and see normally in magical darkness, and can speak, hear, see, and cast spells normally. Any spells or magical effects causing silence or darkness are not dispelled, but they cannot affect any creatures within the negating sphere. If the negating sphere is contained completely within an area of magical silence or magical darkness, any such magical sound or light stops at the edge of the sphere and cannot travel in or out of it.
 
-### Oath to Order
+### _Oath to Order_
 
-_Level 8 Abjuration/Rhythmancy_ (Bard)
+_Level 8 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 8 hours
-- **Range:** Self
-- **Components:** V, S, M (an instrument worth at least 1 gp; a lock of hair from a creature larger than you of Challenge 6 or higher which the spell consumes)
-- **Duration:** 30 days
+**Casting Time:** 8 hours\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a lock of hair from a creature larger than you of Challenge 6 or higher which the spell consumes)\
+**Duration:** 30 days
 
 You call upon the spirits of ancient giants to grant you the ability to repel massive bodies. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
 
@@ -266,27 +280,27 @@ Until the spell ends, as a Magic action, you can target a creature or object wit
 
 Manipulating gravity and mass in this manner takes a physical toll on your body. Each time you attempt to repel a creature, at the end of your turn, you must succeed on a Constitution saving throw contested by your own Spell Save DC or suffer one level of Exhaustion.
 
-### Peaceful Lullaby
+### _Peaceful Lullaby_
 
-_Level 3 Enchantment/Rhythmancy_ (Bard)
+_Level 3 Enchantment/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
 
 You play a gentle melody in an attempt to lull a creature that can hear you in range. The target must succeed on a Wisdom saving throw or fall asleep and remain Unconscious until the spell ends, the target takes damage, or another creature takes an Action to wake them. Constructs and undead automatically succeed on this saving throw.
 
 **At Higher Levels.** When you cast this spell at level 4 or higher, for each spell slot above 3rd, the duration increases by 1 hour, and you can target an additional creature.
 
-### Repel the Dark
+### _Repel the Dark_
 
-_Level 2 Evocation/Rhythmancy_ (Bard)
+_Level 2 Evocation/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 minute
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 minute
 
 You summon the cleansing power of sunlight, causing creatures of the night to cower in fear. When you cast this spell, all Undead creatures and all creatures with sunlight sensitivity within range that can see you must succeed on a Constitution saving throw or become Stunned for the spell's duration. At the end of each of their turns, a creature Stunned by this spell can repeat the saving throw, ending the condition on a success.
 
@@ -294,79 +308,79 @@ For the spell's duration, you shed bright light in a 15-foot radius and dim ligh
 
 **At Higher Levels.** When you cast this spell at level 3 or higher, any creatures forced to make a Constitution saving throw by this spell make their saving throw with Disadvantage if their Challenge Rating is less than the spell's level.
 
-### The River Devil's Lament
+### _The River Devil's Lament_
 
-_Level 6 Enchantment/Rhythmancy_ (Bard)
+_Level 6 Enchantment/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 30 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp; water from a river that flows backward which the spell consumes)
-- **Duration:** 8 hours
+**Casting Time:** 1 minute\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; water from a river that flows backward which the spell consumes)\
+**Duration:** 8 hours
 
-You recite the tale of an ancient hero who drove away a great evil, in order to instill lasting terror in a creature you can see within range that can hear you. That creature must make a Wisdom saving throw. On a failed save, the target is Cursed for the duration of the spell. While Cursed in this manner, the creature is Frightened of you, and if the creature can see you at the start of their turn, they take 3d10 Psychic damage. Creatures that are normally immune to being Frightened are not immune to the Frightened condition caused by this spell's curse. While the Cursed creature cannot see you, they are Frightened of your last known location.
+You recite the tale of an ancient hero who drove away a great evil, in order to instill lasting terror in a creature you can see within range that can hear you. That creature must make a Wisdom saving throw. On a failed save, the target is cursed for the duration of the spell. While cursed in this manner, the creature is Frightened of you, and if the creature can see you at the start of their turn, they take 3d10 Psychic damage. Creatures that are normally immune to being Frightened are not immune to the Frightened condition caused by this spell's curse. While the cursed creature cannot see you, they are Frightened of your last known location.
 
-Each time the creature takes damage (except from this spell's effects), they can repeat their saving throw, ending the Cursed condition on a success. You can additionally choose to end the curse by using a Magic action to dismiss the spell.
+Each time the creature takes damage (except from this spell's effects), they can repeat their saving throw, ending the cursed condition on a success. You can additionally choose to end the curse by using a Magic action to dismiss the spell.
 
 **At Higher Levels.** When you cast this spell at level 7 or higher, the duration increases to 1 day at level 7, 30 days at level 8, or 1 year at level 9, and the Psychic damage dealt when the creature can see you increases by 1d10 for each additional spell level. Additionally, when you cast this spell at level 8 or higher, the creature can no longer repeat their saving throws when they take damage.
 
-### The Royal Decree
+### _The Royal Decree_
 
-_Enchantment/Rhythmancy Cantrip_ (Bard)
+_Enchantment/Rhythmancy Cantrip (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 10 feet
-- **Components:** V, M (a petal from a silent princess flower; an instrument worth at least 1 gp)
-- **Duration:** 1 minute
+**Casting Time:** Action\
+**Range:** 10 feet\
+**Components:** V, M (a petal from a silent princess flower; a Musical Instrument worth 1+ GP)\
+**Duration:** 1 minute
 
 Playing this soothing melody historically indicated a connection to the royal family. Until this spell ends, you are considered to have Proficiency in all Charisma checks used to socially interact with creatures within range that heard you cast the spell.
 
 Your temporary Proficiency in these Charisma checks is further strengthened when you reach higher levels: your Proficiency Bonus is doubled at 5th level, tripled at 11th level, and quadrupled at 17th level.
 
-### Royal Duet
+### _Royal Duet_
 
-_Level 3 Evocation/Rhythmancy (Duet)_ (Bard)
+_Level 3 Evocation/Rhythmancy (Bard)_
 
-- **Casting Time:** 10 minutes
-- **Range:** 10 feet (30-foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** 8 hours
+**Casting Time:** 10 minute Duet\
+**Range:** 10 feet (30-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** 8 hours
 
 You and a partner play an empowering Duet, targeting a shared location within range. When the spell finishes casting, any creatures who remained within the spells' area of effect for the entire casting and were able to hear the entire composition have Advantage on a single d20 test of their choice that they make within the spells' duration.
 
 **At Higher Levels.** When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a d20 test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
 
-### Sonata of Awakening
+### _Sonata of Awakening_
 
-_Level 2 Abjuration/Rhythmancy_ (Bard)
+_Level 2 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, M (an instrument worth at least 1 gp, a bell worth at least 5 gp)
-- **Duration:** Concentration, up to 1 minute
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, M (a Musical Instrument worth 1+ GP, a bell worth 5+ GP)\
+**Duration:** Concentration, up to 1 minute
 
 You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
 
 **At Higher Levels.** When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
 
-### Song of Discovery
+### _Song of Discovery_
 
-_Level 2 Divination/Rhythmancy (Ritual)_ (Bard, Ranger (Wild Composer))
+_Level 2 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 
-- **Casting Time:** 1 minute
-- **Range:** Self (20-foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp, a magnifying glass worth at least 10 gp)
-- **Duration:** Concentration, up to 10 minutes
+**Casting Time:** 1 minute or Ritual\
+**Range:** Self (20-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP, a magnifying glass worth 10+ GP)\
+**Duration:** Concentration, up to 10 minutes
 
 You perform a tune that disrupts any concealing magic in the vicinity. Until the spell ends, as a Magic action, you can attempt to reveal Invisible creatures and objects within your spell's area of effect. Make a spellcasting ability check. If there is a spell causing invisibility in your spell's area of effect, the DC equals 10 + the most powerful such spell's level in the area, or if the only invisibility present is caused by another magical effect, the DC is 15. On a success, all magical invisibility in the area of effect is dispelled, and this spell ends immediately. On a failure, or if there is no such magical invisibility nearby, your spell continues, but you gain no special insight into whether this outcome occurred due to failing the check or no viable Invisible creatures or objects being nearby.
 
-### Song of Healing
+### _Song of Healing_
 
-_Level 5 Evocation/Rhythmancy_ (Bard, Ranger (Wild Composer))
+_Level 5 Evocation/Rhythmancy (Bard, Ranger (Wild Composer))_
 
-- **Casting Time:** 1 minute
-- **Range:** Self (30-foot sphere)
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Instantaneous
+**Casting Time:** 1 minute\
+**Range:** Self (30-foot sphere)\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
 
 You channel healing energies through soothing music. All creatures that remain within 30 feet of you for the entire casting time, except for undead or constructs, regain 5d10 Hit Points and are cured of being Blinded, Deafened, and Diseased.
 
@@ -374,16 +388,16 @@ The healing energy attempts to soothe the restless undead and allow them to move
 
 **At Higher Levels.** When you cast this spell at level 6 or higher, the healing increases by 1d10 for each additional spell level.
 
-When you cast this spell at level 7 or higher, the spell also ends the Cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
+When you cast this spell at level 7 or higher, the spell also ends the cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
-### Song of Passing
+### _Song of Passing_
 
-_Level 5 Illusion/Rhythmancy_ (Bard)
+_Level 5 Illusion/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** 30 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
 
 You attempt to manipulate the apparent flow of time for a creature you target in range that can hear you. The target must make an Intelligence saving throw, and if you are fighting the target, they have advantage on the saving throw. On a failed save, until the spell ends, the target believes that time has passed such that it is either just after sunrise or just after sunset (whichever is the sooner of the two events).
 
@@ -393,14 +407,14 @@ False memories are implanted in the creature's mind, such that they believe time
 
 After the spell ends, the creature becomes aware that their senses and memories were altered by magic.
 
-### Song of Storms
+### _Song of Storms_
 
-_Level 1 Evocation/Rhythmancy_ (Bard)
+_Level 1 Evocation/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 120 feet (1 mile if cast outdoors)
-- **Components:** V, S, M (a pebble or stone worn smooth by water used to forecast rainy weather; an instrument worth at least 1 gp)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** 1 minute\
+**Range:** 120 feet (1 mile if cast outdoors)\
+**Components:** V, S, M (a pebble or stone worn smooth by water used to forecast rainy weather; a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
 
 You summon a storm cloud that is 10 feet tall with a 20-foot radius, centered on a point you can see within range directly above you. The spell fails if you can't see a point in the air where the storm cloud could appear (for example, if you are in a room that can't accommodate the cloud).
 
@@ -408,14 +422,14 @@ Until the spell ends, light rain falls in the area underneath the cloud. Invisib
 
 If you are outdoors in a light rain when you cast this spell, the spell affects the existing storm instead of creating a new cloud. Under such conditions, the storm becomes a heavy rain, causing the area to be lightly obscured, extinguishing open flames, and imposing disadvantage on Wisdom (Perception) checks that rely on sight or hearing. When the spell ends, the weather gradually returns to normal.
 
-### Song of Time
+### _Song of Time_
 
-_Level 1 Abjuration/Rhythmancy_ (Bard)
+_Level 1 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** Action
-- **Range:** Self
-- **Components:** V, S, M (an instrument worth at least 1 gp)
-- **Duration:** 10 minutes
+**Casting Time:** Action\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** 10 minutes
 
 You adjust the flow of time around you, granting you the ability to correct a recent mistake. Until this spell ends, if you fail on an attack roll, ability check, or saving throw, as a Reaction, you can immediately roll a d20 and take the greater of the two results. The first time you fail a check using this spell effect, the spell ends.
 
@@ -423,41 +437,41 @@ You adjust the flow of time around you, granting you the ability to correct a re
 
 If desired, you can alter the performance of the Song of Time to a related composition to create one of the following effects, which replace the spell's normal 1st-level effects:
 
-#### Song of Double Time
+#### _Song of Double Time_
 
 **Song of Double Time (3rd-level or higher).** By playing the Song of Time twice as fast, you move yourself to a moment in the near future, bypassing current events. Select any moment in time in the future up to the end of the spell's duration. You temporarily vanish from existence. At the moment in time you selected when casting the spell, you reappear in the same space from where you vanished, or in the nearest location if that space is occupied. From your perspective, no time has passed. When you reappear, the spell ends.
 
-#### Inverted Song of Time
+#### _Inverted Song of Time_
 
 **Inverted Song of Time (5th-level or higher).** By playing the Song of Time in reverse, you anchor yourself to a moment in time, allowing yourself to complete more tasks in a short time period. Until the spell ends, your speed is doubled, you gain +2 to your AC, you have advantage on Dexterity saving throws, and you gain an additional Action on each of your turns.
 
-### Space Warp
+### _Space Warp_
 
-_Level 4 Conjuration/Rhythmancy (Ritual)_ (Bard)
+_Level 4 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 10 minutes
-- **Range:** 10 feet
-- **Components:** V, S, M (an instrument worth at least 1 gp; an object that was present when the target creature lost consciousness at the spell's destination which the spell consumes)
-- **Duration:** Instantaneous
+**Casting Time:** 10 minutes or Ritual\
+**Range:** 10 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; an object that was present when the target creature lost consciousness at the spell's destination which the spell consumes)\
+**Duration:** Instantaneous
 
 You play a prolonged melody, targeting a willing creature you can see within range and concentrating on a location where the target creature previously was Unconscious, including due to normal or magical sleep. Space then shifts around the target creature, causing them to teleport to a safe location on the outskirts or outside the entrance to your destination.
 
 **At Higher Levels.** When you cast this spell at level 5 or higher, you can teleport an additional willing creature you can see within range to the destination per each additional spell level. When multiple creatures are targeted by this spell, you can choose a destination where any of the target creatures were Unconscious, and the casting time increases by 10 minutes for each additional creature you target beyond the first.
 
-### Soulful Croak
+### _Soulful Croak_
 
-_Level 4 Necromancy/Rhythmancy_ (Bard)
+_Level 4 Necromancy/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 hour
-- **Range:** 20 feet
-- **Components:** V, S, M (a recently deceased frog; an instrument worth at least 1 gp; a gold crown worth at least 300 gp which the spell consumes unless the spell targeted or raised an undead creature)
-- **Duration:** Instantaneous
+**Casting Time:** 1 hour\
+**Range:** 20 feet\
+**Components:** V, S, M (a recently deceased frog; a Musical Instrument worth 1+ GP; a gold crown worth 300+ GP which the spell consumes unless the spell targeted or raised an undead creature)\
+**Duration:** Instantaneous
 
 You attempt to influence the life energy of a corpse or undead creature you can see within range. Make a spellcasting ability check. The target regains all of their Hit Points, then undergoes additional effects depending on the nature of the target and the result of your check:
 
 - **If the target is a corpse that has been dead up to 1 year; the creature's soul is willing and able to rejoin the body; and the creature is not undead:** your spellcasting ability check is contested by a DC equal to the target creature's Challenge or Level (minimum DC 10). If the check succeeds, the creature returns to life, they are no longer Diseased or Poisoned by nonmagical effects, and their mortal wounds are closed (but missing body parts are not restored).
 
-   If the creature was magically Cursed, Diseased, or Poisoned when they died, and these conditions weren't removed prior to casting this spell, they take effect when the creature returns to life. Furthermore, the target takes a −4 penalty to all attack rolls, saving throws, and ability checks. This penalty is reduced by 1 every time the target finishes a Long Rest, after which the penalty disappears.
+   If the creature was magically cursed, Diseased, or Poisoned when they died, and these conditions weren't removed prior to casting this spell, they take effect when the creature returns to life. Furthermore, the target takes a −4 penalty to all attack rolls, saving throws, and ability checks. This penalty is reduced by 1 every time the target finishes a Long Rest, after which the penalty disappears.
 
    Until you finish a Long Rest, you can't cast spells again, and you have disadvantage on all attack rolls, ability checks, and saving throws.
 
@@ -469,40 +483,40 @@ An undead creature targeted or raised by this spell must succeed on a Wisdom sav
 
 On a successful save, or if the Charmed condition on the undead creature ends, the creature stops obeying any command you've given them and cannot be targeted by this spell again for the next 30 days.
 
-### Summoning of the Scarecrow
+### _Summoning of the Scarecrow_
 
-_Level 1 Conjuration/Rhythmancy_ (Bard)
+_Level 1 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 120 feet
-- **Components:** V, S, M (a handful of straw; an instrument worth at least 1 gp)
-- **Duration:** Instantaneous
+**Casting Time:** 1 minute\
+**Range:** 120 feet\
+**Components:** V, S, M (a handful of straw; a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
 
 A Medium-sized inanimate scarecrow appears anchored to the ground in an unoccupied space you can see within range. The destination must have at least enough space to accommodate the scarecrow, or the spell fails.
 
 The scarecrow can act as a target for a thrown grappling hook or similar equipment, and it can support up to 500 pounds of weight. It disappears when you cast this spell again.
 
-### Tune of Ages
+### _Tune of Ages_
 
-_Level 7 Conjuration/Rhythmancy_ (Bard)
+_Level 7 Conjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 hour
-- **Range:** 30 feet
-- **Components:** V, S, M (a magic item or a willing creature from the destination time period; an instrument worth at least 1 gp)
-- **Duration:** Instantaneous
+**Casting Time:** 1 hour\
+**Range:** 30 feet\
+**Components:** V, S, M (a magic item or a willing creature from the destination time period; a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
 
 You and up to eight willing creatures within range are removed from your current time period and appear in the same physical location in another time period you choose.
 
 The selected time period must at least specify the destination year, but can be more specific if desired. Additionally, the magic item or willing creature specified in the spell's material components must have existed in the time period you specify and must accompany you in the time travel. If any of these conditions are not met, the spell fails.
 
-### Tune of Currents
+### _Tune of Currents_
 
-_Level 5 Abjuration/Rhythmancy_ (Bard)
+_Level 5 Abjuration/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** 30 feet
-- **Components:** V, M (an instrument worth at least 1 gp; an item that tells time worth 200 gp which the spell consumes)
-- **Duration:** Instantaneous
+**Casting Time:** 1 minute\
+**Range:** 30 feet\
+**Components:** V, M (a Musical Instrument worth 1+ GP; an item that tells time worth 200 gp which the spell consumes)\
+**Duration:** Instantaneous
 
 You attempt to restore the normal flow of time for a creature you can see within range. This spell can potentially remove the following temporal effects from the target:
 
@@ -514,14 +528,14 @@ Any ongoing spell of level 5 or lower on the target that falls under one of the 
 
 [^⏳]: Source: _Explorer's Guide to Wildemount_
 
-### Tune of Echoes
+### _Tune of Echoes_
 
-_Level 3 Divination/Rhythmancy (Ritual)_ (Bard)
+_Level 3 Divination/Rhythmancy (Bard)_
 
-- **Casting Time:** 1 minute
-- **Range:** Self
-- **Components:** V, S, M (an instrument worth at least 1 gp, a harp string spun from gold worth 25 gp)
-- **Duration:** Concentration, up to 10 minutes
+**Casting Time:** 1 minute or Ritual\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP, a harp string spun from gold worth 25 gp)\
+**Duration:** Concentration, up to 10 minutes
 
 You create an image in the air 10 feet in front of you depicting your current general location from a previous point in time. When you cast the spell, you decide whether the spell depicts a moment of historical significance, or a more specific moment in time you specify. If a moment of historical significance is selected, the Dungeon Master picks the moment to depict, and if no historically significant moment has occurred in this location, the DM can depict any other moment in the past for the same location. If you pick a specific moment, you can be as vague or concrete as you like in your description of the moment, and the spell will attempt to reasonably carry out your request.
 
@@ -529,14 +543,14 @@ For the duration of the spell, the image plays out the selected moment in real t
 
 Any number of times before the spell ends, as a Magic action, you can spend an additional spell slot of any level to extend the spell's duration by a number of minutes equal to ten times the slot level.
 
-### Wind God's Aria
+### _Wind God's Aria_
 
-_Level 4 Evocation/Rhythmancy_ (Bard)
+_Level 4 Evocation/Rhythmancy (Bard)_
 
-- **Casting Time:** 10 minutes
-- **Range:** Self
-- **Components:** V, S, M (an instrument worth at least 1 gp; a vial of air from the Elemental Plane of Air which the spell consumes)
-- **Duration:** 8 hours
+**Casting Time:** 10 minutes\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a vial of air from the Elemental Plane of Air which the spell consumes)\
+**Duration:** 8 hours
 
 The notes you play resonate with the air around you, lifting you upward and granting you free movement.
 
@@ -546,14 +560,14 @@ As long as you are not touching the ground, the air pulses around your body, gra
 
 If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
 
-### Wind's Requiem
+### _Wind's Requiem_
 
-_Level 3 Conjuration/Rhythmancy (Ritual)_ (Bard, Ranger (Wild Composer))
+_Level 3 Conjuration/Rhythmancy (Bard, Ranger (Wild Composer))_
 
-- **Casting Time:** Action
-- **Range:** Self
-- **Components:** V, M (an instrument worth at least 1 gp; a piece of cloth from a ship's sail which the spell consumes)
-- **Duration:** Concentration, up to 1 hour
+**Casting Time:** Action or Ritual\
+**Range:** Self\
+**Components:** V, M (a Musical Instrument worth 1+ GP; a piece of cloth from a ship's sail which the spell consumes)\
+**Duration:** Concentration, up to 1 hour
 
 You create an unnatural strong wind at your back, overriding any existing wind direction affecting you. Until the spell ends, your jumping distance is tripled, and while you are on the deck of a sailing ship, it moves as if it is sailing with the wind. While concentrating on this spell, at the end of each of your turns, you can select a new direction for the winds around you to blow.
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -39,18 +39,46 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 5 | _[Healing Balm](#healing-balm)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
-| 5 | _[Song of Passing](#song-of-passing)_ | Illusion/Rhythmancy | Bard | C |
+| 5 | _[Ballet of the Moon and Sun](#ballet-of-the-moon-and-sun)_ | Illusion/Rhythmancy | Bard | C |
 | 5 | _[Tune of Currents](#tune-of-currents)_ | Abjuration/Rhythmancy | Bard | M |
 | 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
 | 7 | _[Tune of Ages](#tune-of-ages)_ | Conjuration/Rhythmancy | Bard | M |
-| 8 | _[Ballad of Gales](#ballad-of-gales)_ | Conjuration/Rhythmancy | Bard | M |
+| 8 | _[Cast Upon the Seas](#cast-upon-the-seas)_ | Conjuration/Rhythmancy | Bard | M |
 | 8 | _[Hold Back the Skies](#hold-back-the-skies)_ | Abjuration/Rhythmancy | Bard | M |
 
 ## Spell Descriptions
 
 The spells are presented in alphabetical order.
 
-### _Ballad of Gales_
+### _Ballad of the Dreamer_
+
+_Abjuration/Rhythmancy Cantrip (Bard)_
+
+**Casting Time:** Action\
+**Range:** Self\
+**Components:** V, M (a seagull's feather; a Musical Instrument worth 1+ GP)\
+**Duration:** 10 minutes
+
+You play a soothing melody that conjures strange memories of a dream-like world. Until the spell ends, magic can't put you to sleep.
+
+### _Ballet of the Moon and Sun_
+
+_Level 5 Illusion/Rhythmancy (Bard)_
+
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Concentration, up to 1 hour
+
+You attempt to manipulate the apparent flow of time for a creature you target in range that can hear you. The target must make an Intelligence saving throw, and if you are fighting the target, they have advantage on the saving throw. On a failed save, until the spell ends, the target believes that time has passed such that it is either just after sunrise or just after sunset (whichever is the sooner of the two events).
+
+While under the effects of this spell, the creature's senses are modified to convince them of the false time of day. The target's vision makes it appear as if environments are lit by sunlight for a false daytime, or darkened by night for a false nighttime. Any other time-sensitive visuals and sounds (such as a clock's face or a rooster's morning crow) are overlaid with appropriate illusory replacements. The creature is able to see within their illusory environment based on their existing senses as if the illusions are real; for example, a creature with sunlight sensitivity suffers disadvantage on checks that rely on sight while under false daylight conditions of this spell, and a creature with darkvision similarly would be able to see in false nighttime conditions as if it were actually dark. Creatures without darkvision are granted the feature temporarily to allow them to see in dark spaces as if they were lit by illusory daylight.
+
+False memories are implanted in the creature's mind, such that they believe time and events have passed normally. Modified senses and memories don't necessarily affect how a creature behaves, but the creature will make normal efforts to proceed with activities that would make sense for the given time of day. Such activities might include leaving home to work a farm, closing a business for the night, departing for a formal occasion, preparing for bed, or any other time-specific activity.
+
+After the spell ends, the creature becomes aware that their senses and memories were altered by magic.
+
+### _Cast Upon the Seas_
 
 _Level 8 Conjuration/Rhythmancy (Bard)_
 
@@ -64,17 +92,6 @@ If you occupy a vehicle the entire time you cast this spell, you summon a shimme
 You must have seen or been physically present at the destination at least once before, and the destination must have sufficient space to accommodate the vehicle, or the spell fails. The spell also fails when targeting a ship in water if the destination is not also in water.
 
 The act of teleporting the vehicle deals it 8d6 Force damage, ignoring damage thresholds.
-
-### _Ballad of the Dreamer_
-
-_Abjuration/Rhythmancy Cantrip (Bard)_
-
-**Casting Time:** Action\
-**Range:** Self\
-**Components:** V, M (a seagull's feather; a Musical Instrument worth 1+ GP)\
-**Duration:** 10 minutes
-
-You play a soothing melody that conjures strange memories of a dream-like world. Until the spell ends, magic can't put you to sleep.
 
 ### _The Cleansing Waves_
 
@@ -421,23 +438,6 @@ _Level 2 Abjuration/Rhythmancy (Bard)_
 You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
 
 _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
-
-### _Song of Passing_
-
-_Level 5 Illusion/Rhythmancy (Bard)_
-
-**Casting Time:** Action\
-**Range:** 30 feet\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
-**Duration:** Concentration, up to 1 hour
-
-You attempt to manipulate the apparent flow of time for a creature you target in range that can hear you. The target must make an Intelligence saving throw, and if you are fighting the target, they have advantage on the saving throw. On a failed save, until the spell ends, the target believes that time has passed such that it is either just after sunrise or just after sunset (whichever is the sooner of the two events).
-
-While under the effects of this spell, the creature's senses are modified to convince them of the false time of day. The target's vision makes it appear as if environments are lit by sunlight for a false daytime, or darkened by night for a false nighttime. Any other time-sensitive visuals and sounds (such as a clock's face or a rooster's morning crow) are overlaid with appropriate illusory replacements. The creature is able to see within their illusory environment based on their existing senses as if the illusions are real; for example, a creature with sunlight sensitivity suffers disadvantage on checks that rely on sight while under false daylight conditions of this spell, and a creature with darkvision similarly would be able to see in false nighttime conditions as if it were actually dark. Creatures without darkvision are granted the feature temporarily to allow them to see in dark spaces as if they were lit by illusory daylight.
-
-False memories are implanted in the creature's mind, such that they believe time and events have passed normally. Modified senses and memories don't necessarily affect how a creature behaves, but the creature will make normal efforts to proceed with activities that would make sense for the given time of day. Such activities might include leaving home to work a farm, closing a business for the night, departing for a formal occasion, preparing for bed, or any other time-specific activity.
-
-After the spell ends, the creature becomes aware that their senses and memories were altered by magic.
 
 ### _Song of Time_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -44,7 +44,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
 | 7 | _[Tune of Ages](#tune-of-ages)_ | Conjuration/Rhythmancy | Bard | M |
 | 8 | _[Ballad of Gales](#ballad-of-gales)_ | Conjuration/Rhythmancy | Bard | M |
-| 8 | _[Oath to Order](#oath-to-order)_ | Abjuration/Rhythmancy | Bard | M |
+| 8 | _[Hold Back the Skies](#hold-back-the-skies)_ | Abjuration/Rhythmancy | Bard | M |
 
 ## Spell Descriptions
 
@@ -205,6 +205,21 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 6 or hi
 
 When you cast this spell at level 7 or higher, the spell also ends the cursed condition for all creatures healed by this spell. If any of those creatures are Attuned to a cursed magic item, the spell breaks its owner's Attunement to the object so it can be removed or discarded.
 
+### _Hold Back the Skies_
+
+_Level 8 Abjuration/Rhythmancy (Bard)_
+
+**Casting Time:** 8 hours\
+**Range:** Self\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP; a lock of hair from a creature larger than you of Challenge 6 or higher which the spell consumes)\
+**Duration:** 30 days
+
+You call upon the spirits of ancient giants to grant you the ability to repel massive bodies. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
+
+Until the spell ends, as a Magic action, you can target a creature or object within 30 feet of you and attempt to repel them. The target must succeed on a Strength saving throw or they are forcibly shoved a distance of your choice up to 100 feet away from you in a straight line and knocked Prone. If the target is a creature that is already Prone, they are additionally Stunned until the end of your next turn.
+
+Manipulating gravity and mass in this manner takes a physical toll on your body. Each time you attempt to repel a creature, at the end of your turn, you must succeed on a Constitution saving throw contested by your own Spell Save DC or suffer one level of Exhaustion.
+
 ### _The Lost is Found_
 
 _Level 1 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
@@ -273,21 +288,6 @@ _Level 2 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 **Duration:** Concentration, up to 10 minutes
 
 You perform a tune that disrupts any concealing magic in the vicinity. Until the spell ends, as a Magic action, you can attempt to reveal Invisible creatures and objects within your spell's area of effect. Make a spellcasting ability check. If there is a spell causing invisibility in your spell's area of effect, the DC equals 10 + the most powerful such spell's level in the area, or if the only invisibility present is caused by another magical effect, the DC is 15. On a success, all magical invisibility in the area of effect is dispelled, and this spell ends immediately. On a failure, or if there is no such magical invisibility nearby, your spell continues, but you gain no special insight into whether this outcome occurred due to failing the check or no viable Invisible creatures or objects being nearby.
-
-### _Oath to Order_
-
-_Level 8 Abjuration/Rhythmancy (Bard)_
-
-**Casting Time:** 8 hours\
-**Range:** Self\
-**Components:** V, S, M (a Musical Instrument worth 1+ GP; a lock of hair from a creature larger than you of Challenge 6 or higher which the spell consumes)\
-**Duration:** 30 days
-
-You call upon the spirits of ancient giants to grant you the ability to repel massive bodies. The spell can only take effect if you maintain contact with the ground the entire time you cast the spell, otherwise it fails.
-
-Until the spell ends, as a Magic action, you can target a creature or object within 30 feet of you and attempt to repel them. The target must succeed on a Strength saving throw or they are forcibly shoved a distance of your choice up to 100 feet away from you in a straight line and knocked Prone. If the target is a creature that is already Prone, they are additionally Stunned until the end of your next turn.
-
-Manipulating gravity and mass in this manner takes a physical toll on your body. Each time you attempt to repel a creature, at the end of your turn, you must succeed on a Constitution saving throw contested by your own Spell Save DC or suffer one level of Exhaustion.
 
 ### _The Oncoming Storm_
 


### PR DESCRIPTION
- wrote The Curse, Reversed spell (removes low-level curses on creatures within the last hour)
- changed The Royal Decree to grant Expertise at base level, with cantrip upgrade increasing spell duration
- renamed spells:
  - Ballad of Gales to Cast Upon the Seas
  - Command Melody to Souls Entwined
  - Earth God's Lyric to The Sage of Earth's Calling
  - Elegy of Emptiness to An Empty Shell
  - New Wave Bossa Nova to The Cleansing Waves
  - Oath to Order to Hold Back the Skies
  - Sonata of Awakening to Stirring Sonata
  - Song of Discovery to No Stone Unturned
  - Song of Healing to Healing Balm
  - Song of Passing to Ballet of the Moon and Sun
  - Song of Storms to The Oncoming Storm
  - Wind God's Aria to The Sage of Wind's Beckoning
  - Wind's Requiem to The Wind in My Sails
  - Tune of Echoes/Currents/Ages to a three-part movement: Concerto No. 1 in E major, "Echoes of the Past", Concerto No. 2 in G minor, "Ripples of the Current", and Concerto No. 3 in F minor, "Master of the Ages"
- revamped spell formatting to match 2024 rules conventions:
  - moved Ritual and Duet tags to Casting Time
  - italicized spell headers and class lists
  - grouped casting time/range/components/duration in single paragraphs
  - abbreviated special attributes as C, R, M, D
  - wrote spell levels as 1, 2, 3 rather than 1st, 2nd, 3rd