### PR TITLE
College of Legends Bard rework

### DIFF
--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -4,27 +4,25 @@ This section includes new subclass options with abilities centered around the us
 
 ## Bard
 
-At 3rd level, a Bard gains the choice of a subclass. The following option is made available to you when making that choice: the College of Legends.
+At level 3, a Bard gains the choice of a subclass. The following option is made available to you when making that choice: the College of Legends.
 
 ### College of Legends
 
+_Recall Lost Knowledge in Magical Song_
+
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
-#### Legendary Recall
+#### Level 3: Legendary Recall
 
-You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you make an Intelligence check, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
+You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you take the Study action, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
-#### Rhythmantic Savant
+#### Level 3: Rhythmantic Savant
 
 You have an innate understanding of the magic of music and how to wield it. You gain the following benefits.
 
-_**Rhythmancy Points.**_ You have a number of Rhythmancy Points equal to your Bard level divided by 3 (round down) to spend on casting Rhythmancy spells.
+_**Abjurative Melody.**_ When you cast a level 1+ Rhythmancy spell targeting one or more creatures, you can choose to select a number of targets of your choice equal to your Charisma modifier (minimum 1); in addition to the spell's normal effects, the selected targets receive a number of Temporary Hit Points equal to the spell level.
 
-_**Harmonic Magic.**_ Any Bard spell you have prepared is also considered to be a Rhythmancy spell.
-
-_**Speed Training.**_ Whenever you learn a new song through rhythmantic training, you bypass all training requirements, including finding a teacher, all training costs and issues, and any time requirements. Instead, you learn the Rhythmancy spell as a Magic action and by spending a number of Rhythmancy Points equal to the spell's level (minimum 1 Rhythmancy Point). You cannot learn a Rhythmancy spell in this manner if you do not have a sufficient number of Rhythmancy Points available to spend.
-
-_**Abjurative Melody.**_ When you cast a level 1+ Rhythmancy spell targeting one or more creatures, in addition to the spell's normal effects, you can choose to grant any such targets a number of Temporary Hit Points equal to the spell level.
+_**Speed Training.**_ Whenever you learn a new song through rhythmantic training, you bypass all training requirements, including finding a teacher, all training costs and issues, and any time requirements. Instead, you learn the Rhythmancy spell as a Magic action and by expending either a spell slot of a level greater than or equal to the spell's level, or that number of Rhythmancy Points (for cantrips, expend either a level 1 spell slot or 1 Rhythmancy Point). You cannot learn a Rhythmancy spell in this manner if you do not have an appropriate spell slot or sufficient Rhythmancy Points available to expend.
 
 #### Level 6: Inner Song
 
@@ -32,7 +30,7 @@ You can channel your song to temporarily boost the power of your rhythmantic mag
 
 #### Level 14: Legendary Secrets
 
-You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. When you cast _Legend Lore_ using Rhythmancy Points, the casting time is 1 action, and you replace its Material component requirements with an instrument worth at least 1 GP.
+You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. You can cast it once without expending a spell slot, and you regain the ability to do so when you finish a Long Rest. When you cast _Legend Lore_ using this feature, you can cast it as an action rather than its normal casting time, and you ignore its Material component requirements. You can also cast _Legend Lore_ normally using a spell slot of the appropriate level.
 
 ## Ranger
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -26,7 +26,7 @@ _**Speed Training.**_ Whenever you learn a new song through rhythmantic training
 
 #### Level 6: Inner Song
 
-You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the level of Rhythmancy spell you can cast or learn. Unspent temporary Rhythmancy Points from this feature disappear after you finish your next Long Rest.
+You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the highest level of Rhythmancy spell you can cast or learn. Unspent temporary Rhythmancy Points from this feature disappear after you finish your next Long Rest.
 
 #### Level 14: Legendary Secrets
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -14,19 +14,25 @@ Though all bards have the ability to learn rhythmancy spells, practitioners of t
 
 #### Level 3: Legendary Recall
 
-You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you take the Study action, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
+You have extensively pored through history books and sought out hidden knowledge of ancient heroes and their adventures. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you take the Study action, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
 #### Level 3: Rhythmantic Savant
 
-You have an innate understanding of the magic of music and how to wield it. You gain the following benefits.
+You have an innate understanding of the magic of music and how to modify your compositions. When you cast a level 1+ Rhythmancy spell targeting one or more creatures, you can select one target of the spell and modify your musical performance to enhance the spell using one of the following effects (in addition to the spell's normal effects). The enhancement succeeds only if one of the following conditions are met: the target is willing; the target is hit by an attack roll triggered by the spell; or the target fails a saving throw triggered by the spell.
 
-_**Abjurative Melody.**_ When you cast a level 1+ Rhythmancy spell targeting one or more creatures, you can choose to select a number of targets of your choice equal to your Charisma modifier (minimum 1); in addition to the spell's normal effects, the selected targets receive a number of Temporary Hit Points equal to the spell level.
+- _**Abjurative Melody.**_ The target receives a number of Temporary Hit Points equal to a roll of your Bardic Inspiration die.
+- _**Enchanting Tune.**_ The target has the Charmed condition until the end of your next turn. You cannot select this effect if the spell you cast is already capable of granting the Charmed condition.
+- _**Evocative Beat.**_ The target takes Thunder damage equal to a roll of your Bardic Inspiration die.
 
-_**Speed Training.**_ Whenever you learn a new song through rhythmantic training, you bypass all training requirements, including finding a teacher, all training costs and issues, and any time requirements. Instead, you learn the Rhythmancy spell as a Magic action and by expending either a spell slot of a level greater than or equal to the spell's level, or that number of Rhythmancy Points (for cantrips, expend either a level 1 spell slot or 1 Rhythmancy Point). You cannot learn a Rhythmancy spell in this manner if you do not have an appropriate spell slot or sufficient Rhythmancy Points available to expend.
+Once you enhance a spell with one of the selected effects, you regain the ability to select that enhancement when you finish a Long Rest, or by expending one use of Bardic Inspiration.
 
 #### Level 6: Inner Song
 
-You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the highest level of Rhythmancy spell you can cast or learn. Unspent temporary Rhythmancy Points from this feature disappear after you finish your next Long Rest.
+You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the highest level of Rhythmancy spell you can cast or learn. Any unspent temporary Rhythmancy Points disappear after you finish your next Long Rest.
+
+#### Level 6: Speed Training
+
+Whenever you learn a new song through rhythmantic training, you bypass all training requirements, including finding a teacher, all training costs and issues, and any time requirements. Instead, you learn the Rhythmancy spell as a Magic action and by expending either a spell slot of a level greater than or equal to the spell's level, or that number of Rhythmancy Points (for cantrips, expend either a level 1 spell slot or 1 Rhythmancy Point). You cannot learn a Rhythmancy spell in this manner if you do not have an appropriate spell slot or sufficient Rhythmancy Points available to expend.
 
 #### Level 14: Legendary Secrets
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -1,22 +1,22 @@
 # Chapter 3: Rhythmancy Classes
 
-This section includes new subclass options with abilities centered around the use of rhythmancy magic.
+This chapter presents new subclasses with abilities centered around the use of rhythmancy magic:
 
-## Bard
+- **College of Legends:** A Bard who enhances magic with musical performance
 
-At level 3, a Bard gains the choice of a subclass. The following option is made available to you when making that choice: the College of Legends.
+- **Wild Composer:** A Ranger who crafts magical instruments to share the music of nature
 
-### College of Legends
+## College of Legends (Bard)
 
 _Recall Lost Knowledge in Magical Song_
 
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
-#### Level 3: Legendary Recall
+### Level 3: Legendary Recall
 
 You have extensively pored through history books and sought out hidden knowledge of ancient heroes and their adventures. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you take the Study action, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
-#### Level 3: Rhythmantic Savant
+### Level 3: Rhythmantic Savant
 
 You have an innate understanding of the magic of music and how to modify your compositions. When you cast a level 1+ Rhythmancy spell targeting one or more creatures, you can select one target of the spell and modify your musical performance to enhance the spell using one of the following effects (in addition to the spell's normal effects). The enhancement succeeds only if one of the following conditions are met: the target is willing; the target is hit by an attack roll triggered by the spell; or the target fails a saving throw triggered by the spell.
 
@@ -26,23 +26,19 @@ You have an innate understanding of the magic of music and how to modify your co
 
 Once you enhance a spell with one of the selected effects, you regain the ability to select that enhancement when you finish a Long Rest, or by expending one use of Bardic Inspiration.
 
-#### Level 6: Inner Song
+### Level 6: Inner Song
 
 You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the highest level of Rhythmancy spell you can cast or learn. Any unspent temporary Rhythmancy Points disappear after you finish your next Long Rest.
 
-#### Level 6: Speed Training
+### Level 6: Speed Training
 
 Whenever you learn a new song through rhythmantic training, you bypass all training requirements, including finding a teacher, all training costs and issues, and any time requirements. Instead, you learn the Rhythmancy spell as a Magic action and by expending either a spell slot of a level greater than or equal to the spell's level, or that number of Rhythmancy Points (for cantrips, expend either a level 1 spell slot or 1 Rhythmancy Point). You cannot learn a Rhythmancy spell in this manner if you do not have an appropriate spell slot or sufficient Rhythmancy Points available to expend.
 
-#### Level 14: Legendary Secrets
+### Level 14: Legendary Secrets
 
 You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. You can cast it once without expending a spell slot, and you regain the ability to do so when you finish a Long Rest. When you cast _Legend Lore_ using this feature, you can cast it as an action rather than its normal casting time, and you ignore its Material component requirements. You can also cast _Legend Lore_ normally using a spell slot of the appropriate level.
 
-## Ranger
-
-At 3rd level, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.
-
-### Wild Composer
+## Wild Composer (Ranger)
 
 > You know there's rhythm all around us: the waves break in rhythm, people walk in rhythm, people breathe in rhythm, too. People work in rhythm! The whole world is made up of rhythm.
 >
@@ -50,11 +46,11 @@ At 3rd level, a Ranger gains the choice of a subclass. The following option is m
 
 Rangers who walk the path of the Wild Composer are drawn to the innate music present in the natural world. They revel in the melody of leaves rustling in the wind like chimes, and play along as woodpeckers drum a steady beat on tall steadfast trees. To these adventurers, the wild itself has a breath and cadence that grants those who can hear it great wisdom.
 
-#### Wild Composer Spells
+### Wild Composer Spells
 
 When you reach a Ranger level specified in the Wild Composer Spells table, you thereafter always have the listed spells prepared.
 
-##### Wild Composer Spells
+#### Wild Composer Spells
 
 | Ranger Level | Spells |
 |:------------:|:-------|
@@ -64,7 +60,7 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 | 13 | _Earth God's Lyric_ |
 | 17 | _Song of Healing_ |
 
-#### Music-Maker
+### Music-Maker
 
 You are in sync with the music of the wilds, allowing you to direct nature's song into musical instruments. You gain the following benefits.
 
@@ -78,19 +74,19 @@ An **Instrument of the Wild** you create contains a number of charges equal to t
 
 You regain the ability to craft an **Instrument of the Wild** using this feature after you finish a Long Rest. You can maintain the magical properties in a number of **Instruments of the Wild** equal to the highest level Ranger spell you know. If you craft an **Instrument of the Wild** beyond your limit, one such instrument of your choice loses all of its magical properties, becoming a mundane version of that instrument.
 
-#### Level 7: Rhythm of the World
+### Level 7: Rhythm of the World
 
 Your connection to the world's secret song strengthens. While you are Attuned to an **Instrument of the Wild**, your Rhythmancy spells gain a +1 to their attack rolls and total damage rolls, and when you cast a level 1+ Rhythmancy spell, you can expend one of the instrument's charges to cast the spell at one level higher than the original spell level; for example, casting a level 1 Rhythmancy spell and expending a charge would cast that spell at level 2.
 
 Additionally, you gain the ability to tap into the music of an unfamiliar environment and learn its underlying structure. When you cast _The Lost is Found_, for the spell's duration or until you leave the same environment you were in when casting the spell, the environment is considered to be your favored terrain, granting you Expertise in Intelligence and Wisdom checks you make related to the terrain.
 
-#### Level 11: Song of Leaf and Claw
+### Level 11: Song of Leaf and Claw
 
 Your ear for the songs of the natural world allows you to channel your magic through that musical structure. If you prepare any of the following Ranger spells, they are also considered to be Rhythmancy spells: _Animal Friendship_, _Beast Bond_, _Locate Animals or Plants_, _Speak with Animals_, and _Speak with Plants_. If you cast one of these spells using Rhythmancy Points or **Instrument of the Wild** charges, the Rhythmancy Point and instrument charge cost is reduced by 1.
 
 In addition, when you cast a Rhythmancy spell with a casting time of 1 action, you can make a melee or ranged weapon attack as a Bonus Action.
 
-#### Level 15: World Strider
+### Level 15: World Strider
 
 You recall every tree you have encountered, and can travel through the world's root systems to be reunited with them at a moment's notice. You always have the _Tree Stride_ spell prepared, and you can cast it by expending a level 4+ spell slot. Starting at level 17, you always have the _Transport via Plants_ spell prepared, and you can cast it by expending a level 5+ spell slot.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -10,6 +10,10 @@ This chapter presents new subclasses with abilities centered around the use of r
 
 _Recall Lost Knowledge in Magical Song_
 
+> "My teacher always advised me to write songs that transport the listener to the moment in time you're singing of. Now… I finally feel I understand what he meant… and the true power of music."
+>
+> — Kass, _The Legend of Zelda: Breath of the Wild_
+
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
 ### Level 3: Legendary Recall
@@ -42,7 +46,7 @@ You have mastered unlocking hidden or lost ancient secrets. You always have the 
 
 _Share Nature's Song in Magic Instruments_
 
-> You know there's rhythm all around us: the waves break in rhythm, people walk in rhythm, people breathe in rhythm, too. People work in rhythm! The whole world is made up of rhythm.
+> "You know there's rhythm all around us: the waves break in rhythm, people walk in rhythm, people breathe in rhythm, too. People work in rhythm! The whole world is made up of rhythm."
 >
 > — Victor Brady, _[Let's Go Play to the Rhythm of the World](https://youtu.be/g1zNAbrU1zM)_
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ This document includes a list of class options, feats, spells, and magic items u
 
 ### [Chapter 3: Rhythmancy Classes](ch-3-rhythmancy-classes.md)
 
-- [Bard Subclass: College of Legends](ch-3-rhythmancy-classes.md#college-of-legends)
-- [Ranger Subclass: Wild Composer](ch-3-rhythmancy-classes.md#wild-composer)
+- [College of Legends (Bard)](ch-3-rhythmancy-classes.md#college-of-legends-bard)
+- [Wild Composer (Ranger)](ch-3-rhythmancy-classes.md#wild-composer-ranger)
 
 ### [Chapter 4: Rhythmancy Feats](ch-4-rhythmancy-feats.md)
 

--- a/docs/rules-definitions.md
+++ b/docs/rules-definitions.md
@@ -8,7 +8,6 @@ This work is compatible with Dungeons & Dragons 5th Edition.
 
 This document makes the following modifications from the _SRD_:
 
-- To ensure compatibility with characters created using both the 2014 and 2024 fifth edition ruleset, base-level class and subclass features in this document do not include a level requirement, unless they have additional feature dependencies. You gain such features as soon as you select the corresponding class or subclass.
 - This document uses new traits called **Condition Resistance** and **Condition Vulnerability**. Resistance to a condition means that a creature has Advantage on saving throws made to resist that condition, and vulnerability to a condition means that a creature has Disadvantage on such saving throws.
 - Damage and condition resistance, vulnerability, and immunity are now grouped together as **Resistances**, **Vulnerabilities**, and **Immunities** respectively.
 - Resistance, vulnerability, and immunity to Poison apply to both the damage type and the Poisoned condition.


### PR DESCRIPTION
- reworked College of Legends Bard:
  - added subclass tagline and relevant quote
  - Legendary Recall: replaced INT checks with Study action
  - Rhythmantic Savant:
    - removed Rhythmancy Points subfeature
    - removed Harmonic Magic subfeature
    - now applies your choice of enhanced effect to Rhythmancy spells on one of the spell targets: Abjurative Melody (Bardic Inspiration die temp HP), Enchanting Tune (Charmed condition), or Evocative Beat (Thunder damage)
    - each enhanced effect is 1/LR or recharged by Bardic Inspiration
  - Speed Training:
    - moved to standalone level 6 feature
    - can now expend a spell slot or RP to learn Rhythmancy spells
    - sets cost of level 1 slot or 1 RP to learn cantrips
  - Legendary Secrets: can now cast Legend Lore 1/day without a spell slot as an action, and this use bypasses Material components
  - added level requirements for all subclass features
- removed compatibility note explaining old behavior of "no level prefix for base subclass features" since it's no longer relevant