### PR TITLE
Wild Composer Ranger rework

### DIFF
--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -1,20 +1,20 @@
 # Chapter 3: Rhythmancy Classes
 
-This section includes new subclass options with abilities centered around the use of rhythmancy magic.
+This chapter presents new subclasses with abilities centered around the use of rhythmancy magic:
 
-## Bard
+- **College of Legends:** A Bard who enhances magic with musical performance
 
-At 3rd level, a Bard gains the choice of a subclass. The following option is made available to you when making that choice: the College of Legends.
+- **Wild Composer:** A Ranger who crafts magical instruments to share the music of nature
 
-### College of Legends
+## College of Legends (Bard)
 
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
-#### Legendary Recall
+### Level 3: Legendary Recall
 
 You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you make an Intelligence check, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
-#### Rhythmantic Savant
+### Level 3: Rhythmantic Savant
 
 You have an innate understanding of the magic of music and how to wield it. You gain the following benefits.
 
@@ -26,19 +26,15 @@ _**Speed Training.**_ Whenever you learn a new song through rhythmantic training
 
 _**Abjurative Melody.**_ When you cast a level 1+ Rhythmancy spell targeting one or more creatures, in addition to the spell's normal effects, you can choose to grant any such targets a number of Temporary Hit Points equal to the spell level.
 
-#### Level 6: Inner Song
+### Level 6: Inner Song
 
 You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the level of Rhythmancy spell you can cast or learn. Unspent temporary Rhythmancy Points from this feature disappear after you finish your next Long Rest.
 
-#### Level 14: Legendary Secrets
+### Level 14: Legendary Secrets
 
 You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. When you cast _Legend Lore_ using Rhythmancy Points, the casting time is 1 action, and you replace its Material component requirements with an instrument worth at least 1 GP.
 
-## Ranger
-
-At level 3, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.
-
-### Wild Composer
+## Wild Composer (Ranger)
 
 _Share Nature's Song in Magic Instruments_
 
@@ -48,11 +44,11 @@ _Share Nature's Song in Magic Instruments_
 
 Rangers who walk the path of the Wild Composer are drawn to the innate music present in the natural world. They revel in the melody of leaves rustling in the wind like chimes, and play along as woodpeckers drum a steady beat on tall steadfast trees. To these adventurers, the wild itself has a breath and cadence that grants those who can hear it great wisdom.
 
-#### Level 3: Wild Composer Spells
+### Level 3: Wild Composer Spells
 
 When you reach a Ranger level specified in the Wild Composer Spells table, you thereafter always have the listed spells prepared.
 
-##### Wild Composer Spells
+#### Wild Composer Spells
 
 | Ranger Level | Spells |
 |:------------:|:-------|
@@ -62,7 +58,7 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 | 13 | _Earth God's Lyric_ |
 | 17 | _Song of Healing_ |
 
-#### Level 3: Music-Maker
+### Level 3: Music-Maker
 
 You are in sync with the music of the wilds, allowing you to direct nature's song into musical instruments. You gain the following benefits.
 
@@ -76,19 +72,19 @@ An **Instrument of the Wild** you create contains a number of charges equal to t
 
 You regain the ability to craft an **Instrument of the Wild** using this feature after you finish a Long Rest. You can maintain the magical properties in a number of **Instruments of the Wild** equal to the highest level Ranger spell you know. If you craft an **Instrument of the Wild** beyond your limit, one such instrument of your choice loses all of its magical properties, becoming a mundane version of that instrument.
 
-#### Level 7: Rhythm of the World
+### Level 7: Rhythm of the World
 
 Your connection to the world's secret song strengthens. While you are Attuned to an **Instrument of the Wild**, your Rhythmancy spells gain a +1 to their attack rolls and total damage rolls, and when you cast a level 1+ Rhythmancy spell, you can expend one of the instrument's charges to cast the spell at one level higher than the original spell level; for example, casting a level 1 Rhythmancy spell and expending a charge would cast that spell at level 2.
 
 Additionally, you gain the ability to tap into the music of an unfamiliar environment and learn its underlying structure. When you cast _The Lost is Found_, for the spell's duration or until you leave the same environment you were in when casting the spell, the environment is considered to be your favored terrain, granting you Expertise in Intelligence and Wisdom checks you make related to the terrain.
 
-#### Level 11: Song of Leaf and Claw
+### Level 11: Song of Leaf and Claw
 
 Your ear for the songs of the natural world allows you to channel your magic through that musical structure. If you prepare any of the following Ranger spells, they are also considered to be Rhythmancy spells: _Animal Friendship_, _Beast Bond_, _Locate Animals or Plants_, _Speak with Animals_, and _Speak with Plants_. If you cast one of these spells using Rhythmancy Points or **Instrument of the Wild** charges, the Rhythmancy Point and instrument charge cost is reduced by 1.
 
 In addition, when you cast a Rhythmancy spell with a casting time of 1 action, you can make a weapon attack as a Bonus Action.
 
-#### Level 15: World Strider
+### Level 15: World Strider
 
 You recall every tree you have encountered, and can travel through the world's root systems to be reunited with them at a moment's notice. You always have the _Tree Stride_ spell prepared, and you can cast it by expending a level 4+ spell slot. Starting at level 17, you always have the _Transport via Plants_ spell prepared, and you can cast it by expending a level 5+ spell slot.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -36,9 +36,11 @@ You have mastered unlocking hidden or lost ancient secrets. You always have the 
 
 ## Ranger
 
-At 3rd level, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.
+At level 3, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.
 
 ### Wild Composer
+
+_Share Nature's Song in Magic Instruments_
 
 > You know there's rhythm all around us: the waves break in rhythm, people walk in rhythm, people breathe in rhythm, too. People work in rhythm! The whole world is made up of rhythm.
 >
@@ -46,7 +48,7 @@ At 3rd level, a Ranger gains the choice of a subclass. The following option is m
 
 Rangers who walk the path of the Wild Composer are drawn to the innate music present in the natural world. They revel in the melody of leaves rustling in the wind like chimes, and play along as woodpeckers drum a steady beat on tall steadfast trees. To these adventurers, the wild itself has a breath and cadence that grants those who can hear it great wisdom.
 
-#### Wild Composer Spells
+#### Level 3: Wild Composer Spells
 
 When you reach a Ranger level specified in the Wild Composer Spells table, you thereafter always have the listed spells prepared.
 
@@ -60,11 +62,11 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 | 13 | _Earth God's Lyric_ |
 | 17 | _Song of Healing_ |
 
-#### Music-Maker
+#### Level 3: Music-Maker
 
 You are in sync with the music of the wilds, allowing you to direct nature's song into musical instruments. You gain the following benefits.
 
-_**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice, and with a tool of your choice capable of crafting that instrument (Leatherworker's Tools, Potter's Tools, or Woodworker's Tools might be suitable choices).
+_**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice, and with a tool of your choice capable of crafting that instrument. Leatherworker's Tools, Potter's Tools, or Woodworker's Tools might be suitable choices.
 
 _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Ranger spells.
 
@@ -84,7 +86,7 @@ Additionally, you gain the ability to tap into the music of an unfamiliar enviro
 
 Your ear for the songs of the natural world allows you to channel your magic through that musical structure. If you prepare any of the following Ranger spells, they are also considered to be Rhythmancy spells: _Animal Friendship_, _Beast Bond_, _Locate Animals or Plants_, _Speak with Animals_, and _Speak with Plants_. If you cast one of these spells using Rhythmancy Points or **Instrument of the Wild** charges, the Rhythmancy Point and instrument charge cost is reduced by 1.
 
-In addition, when you cast a Rhythmancy spell with a casting time of 1 action, you can make a melee or ranged weapon attack as a Bonus Action.
+In addition, when you cast a Rhythmancy spell with a casting time of 1 action, you can make a weapon attack as a Bonus Action.
 
 #### Level 15: World Strider
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ This document includes a list of class options, feats, spells, and magic items u
 
 ### [Chapter 3: Rhythmancy Classes](ch-3-rhythmancy-classes.md)
 
-- [Bard Subclass: College of Legends](ch-3-rhythmancy-classes.md#college-of-legends)
-- [Ranger Subclass: Wild Composer](ch-3-rhythmancy-classes.md#wild-composer)
+- [College of Legends (Bard)](ch-3-rhythmancy-classes.md#college-of-legends-bard)
+- [Wild Composer (Ranger)](ch-3-rhythmancy-classes.md#wild-composer-ranger)
 
 ### [Chapter 4: Rhythmancy Feats](ch-4-rhythmancy-feats.md)
 


### PR DESCRIPTION
- reworked Wild Composer Ranger:
  - added subclass tagline
  - Song of Leaf and Claw: generalized "weapon attack" instead of "melee or ranged weapon attack"
  - added level requirements for all subclass features
  - minor rewording on some features for clarity