### PR TITLE
Warrior of Song Monk

### DIFF
--- a/docs/ch-2-casting-rhythmancy-spells.md
+++ b/docs/ch-2-casting-rhythmancy-spells.md
@@ -30,9 +30,9 @@ If the casting of a spell using such features is subject to special rules and li
 
 ### Focus Points
 
-If a monk feature requires spending Focus Points to cast a spell of level 1 or higher, the cost of casting a rhythmancy spell is a number of Focus Points equal to 1 + the spell's level. For example, casting _Song of Storms_ using the Empty Body feature would require spending 3 Focus Points.
+If a Monk feature allows spending Focus Points to cast a level 1+ spell, casting a Rhythmancy spell costs the same as that feature's spell of the same level. For example, casting _Song of Storms_ using a Warrior of Shadows Monk's Shadow Arts feature would require spending 1 Focus Point.
 
-Additional Focus Points can be spent to cast the spell at a higher level at 1 Discipline Point per level increase, as long as you already have the ability to cast a spell at that level using Focus Points.
+Additional Focus Points can be spent to cast the spell at a higher level at a cost of 1 Focus Point per level increase, as long as the Monk already has the ability to cast a spell at that higher level using Focus Points.
 
 ### Limited Uses
 

--- a/docs/ch-2-casting-rhythmancy-spells.md
+++ b/docs/ch-2-casting-rhythmancy-spells.md
@@ -30,7 +30,7 @@ If the casting of a spell using such features is subject to special rules and li
 
 ### Focus Points
 
-If a Monk feature allows spending Focus Points to cast a level 1+ spell, casting a Rhythmancy spell costs the same as that feature's spell of the same level. For example, casting _Song of Storms_ using a Warrior of Shadows Monk's Shadow Arts feature would require spending 1 Focus Point.
+If a Monk feature allows spending Focus Points to cast a level 1+ spell, casting a Rhythmancy spell costs the same as that feature's spell of the same level. For example, casting _The Oncoming Storm_ using the Warrior of Shadows Monk's Shadow Arts feature would require spending 1 Focus Point.
 
 Additional Focus Points can be spent to cast the spell at a higher level at a cost of 1 Focus Point per level increase, as long as the Monk already has the ability to cast a spell at that higher level using Focus Points.
 
@@ -38,15 +38,13 @@ Additional Focus Points can be spent to cast the spell at a higher level at a co
 
 If the feature or trait requires spending from a limited number of charges to cast spells, casting a rhythmancy spell costs the same as another spell of the same level or higher.
 
-If the feature or trait allows casting spells of level 1 or higher once before requiring a rest to recharge (such as the Infernal Legacy trait), the rhythmancy spell can be selected in place of the existing spell options, expending the spell use as if it were the existing spell.
+If the feature or trait allows casting spells of level 1 or higher once before requiring a rest to recharge (such as the Tiefling's Infernal Legacy trait), the rhythmancy spell can be selected in place of the existing spell options, expending the spell use as if it were the existing spell.
 
 If the feature or trait allows casting a spell of level 1 or higher an unlimited number of times, you can choose to cast a rhythmancy spell of the same spell level or lower once with this trait. Once you cast it, you can't do so again until you finish a Long Rest, but you can continue to use the default spell from this trait as normal.
 
 ### Spell Limitations
 
-If a feature or trait imposes any other limitations on casting its existing spells, the rhythmancy spell must follow those same limitations. For example, the Empty Body feature doesn't allow taking creatures with you when casting _Astral Projection_, so a rhythmancy spell cast in this manner also cannot take creatures with you if it normally has this ability.
-
-If the spell cannot be used with the feature's limitations, it cannot be learned in this manner. For example, the Ascendant Step eldritch invocation only allows casting _Levitate_ on yourself, so if a rhythmancy spell is unable to target yourself, you cannot learn it using Ascendant Step.
+If a feature or trait imposes any limitations on casting its existing spells, the Rhythmancy spell must follow those same limitations. For example, the Warlock's Ascendant Step feature only allows casting _Levitate_ on yourself, so a Rhythmancy spell cast using this feature similarly must be cast targeting yourself. If the Rhythmancy spell is unable to follow these limitations, it cannot be learned using this feature.
 
 ## Duets
 

--- a/docs/ch-2-casting-rhythmancy-spells.md
+++ b/docs/ch-2-casting-rhythmancy-spells.md
@@ -30,7 +30,7 @@ If the casting of a spell using such features is subject to special rules and li
 
 ### Focus Points
 
-If a Monk feature allows spending Focus Points to cast a level 1+ spell, casting a Rhythmancy spell costs the same as that feature's spell of the same level. For example, casting _The Oncoming Storm_ using the Warrior of Shadows Monk's Shadow Arts feature would require spending 1 Focus Point.
+If a Monk feature allows spending Focus Points to cast a level 1+ spell, casting a Rhythmancy spell costs the same as that feature's spell of the same level. For example, casting _[The Oncoming Storm](ch-5-rhythmancy-spells.md#the-oncoming-storm)_ using the Warrior of Shadows Monk's Shadow Arts feature would require spending 1 Focus Point.
 
 Additional Focus Points can be spent to cast the spell at a higher level at a cost of 1 Focus Point per level increase, as long as the Monk already has the ability to cast a spell at that higher level using Focus Points.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,7 +64,7 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point.
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast your Bard spells at higher levels at a cost of 1 Focus Point per level increase, but the maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
 
 _**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 
@@ -80,11 +80,15 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 ### Level 6: Vanish
 
-As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared and can cast it for 1 Focus Point. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
+As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared and can cast it by spending 1 Focus Point. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
 ### Level 11: Song-Empowered Strikes
 
 You have learned how to weave arcane effects into your attacks. Once per turn, when you make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of an action and a range of either touch or self. You can't cast a spell in this way if you've already cast a level 1+ spell on the current turn, nor can you cast a level 1+ spell on this turn after casting a spell in this way.
+
+### Level 11: Space Warp
+
+You have learned a secret song that enables instantaneous long-distance travel. You always have the _Space Warp_ spell prepared and can cast it by spending 3 Focus Points.
 
 ### Level 17: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -2,13 +2,13 @@
 
 This chapter presents new subclasses with abilities centered around the use of rhythmancy magic:
 
-- **College of Legends:** A Bard who enhances magic with musical performance
+- **[College of Legends](#college-of-legends-bard):** A Bard who enhances magic with musical performance
 
-- **Reveler:** A Fighter who dances to the rhythm of magical song
+- **[Reveler](#reveler-fighter):** A Fighter who dances to the rhythm of magical song
 
-- **Warrior of Song:** A Monk imparting ancient knowledge through oral tradition
+- **[Warrior of Song](#warrior-of-song-monk):** A Monk imparting ancient knowledge through oral tradition
 
-- **Wild Composer:** A Ranger who crafts magical instruments to share the music of nature
+- **[Wild Composer](#wild-composer-ranger):** A Ranger who crafts magical instruments to share the music of nature
 
 ## College of Legends (Bard)
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -12,11 +12,11 @@ This chapter presents new subclasses with abilities centered around the use of r
 
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
-### Legendary Recall
+### Level 3: Legendary Recall
 
 You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you make an Intelligence check, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
-### Rhythmantic Savant
+### Level 3: Rhythmantic Savant
 
 You have an innate understanding of the magic of music and how to wield it. You gain the following benefits.
 
@@ -66,7 +66,7 @@ _Impart Wisdom through Ancient Melody_
 
 Rangers who walk the path of the Wild Composer are drawn to the innate music present in the natural world. They revel in the melody of leaves rustling in the wind like chimes, and play along as woodpeckers drum a steady beat on tall steadfast trees. To these adventurers, the wild itself has a breath and cadence that grants those who can hear it great wisdom.
 
-### Wild Composer Spells
+### Level 3: Wild Composer Spells
 
 When you reach a Ranger level specified in the Wild Composer Spells table, you thereafter always have the listed spells prepared.
 
@@ -80,7 +80,7 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 | 13 | _Earth God's Lyric_ |
 | 17 | _Song of Healing_ |
 
-### Music-Maker
+### Level 3: Music-Maker
 
 You are in sync with the music of the wilds, allowing you to direct nature's song into musical instruments. You gain the following benefits.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,7 +64,7 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell). The maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell). The maximum number of Focus Points you can spend on casting a spell equals half your Monk level (round down).
 
 _**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -111,7 +111,7 @@ _Impart Wisdom through Ancient Melody_
 >
 > — Sheik, _The Legend of Zelda: Ocarina of Time_
 
-Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information—often encoded within rhythmantic compositions and poems—under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world. Eventually this includes the knowledge of magical teleportation.
+In some monasteries, a single Monk will choose to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information—often encoded within rhythmantic compositions and poems—under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
 
 ### Level 3: Keeper of Secrets
 
@@ -143,7 +143,7 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 When you find a worthy ally, you can impart a portion of your wisdom to aid them on their quest. As a Magic action, you can expend one Focus Point and touch a willing creature to grant it the ability to cast one Rhythmancy spell of your choice that you have prepared. It can cast this spell by expending the required number of your Focus Points, or by using a spell slot of the appropriate level or sufficient Rhythmancy Points it possesses. The creature must be on the same plane of existence as you to cast one of your spells in this manner. The spell uses your spellcasting ability and Proficiency Bonus when the target casts it.
 
-This effect lasts until the creature casts your spell. You can also end the effect at any time (no action required).
+This effect lasts until either the creature casts your spell or you finish a Long Rest. You can also end the effect at any time (no action required).
 
 ### Level 6: Vanish
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -66,9 +66,9 @@ _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority gr
 
 _**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. The maximum amount of Focus Points you can spend for casting a spell, including casting it at a higher level, equals your Monk level divided by 3 (round down).
 
-_**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose one level 1 spell from the Bard spell list.
+_**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose one level 1 spell from the Bard spell list.
 
-Whenever you gain a level that grants the Ability Score Improvement feature, add another level 1 Bard spell to your list of prepared spells.
+Whenever you gain a level that grants the Ability Score Improvement feature, add another Bard spell to your list of prepared spells. The chosen spell must be of a level for which you have sufficient Focus Points.
 
 If another Warrior of Song feature gives you spells that you always have prepared, those spells don't count against the number of spells you can prepare with this feature, but those spells otherwise count as Bard spells for you.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -62,17 +62,23 @@ You have been trained to act as a living compendium of ancient knowledge, and ca
 
 You have engaged in the study of magic song and incorporated it into your combat training. You gain the following benefits.
 
-_**Ancient Training.**_ Choose one level 1 Rhythmancy spell. You always have the selected spell prepared. Whenever you gain a Monk level, you can replace this spell with another level 1 Rhythmancy spell.
+_**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Rhythmantic Focus.**_ You can cast spells you know from Warrior of Song features, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level.
+_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. You cannot cast a level 4+ spell using Focus Points.
 
-_**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
+_**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose one level 1 spell from the Bard spell list.
 
-_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Warrior of Song spells.
+Whenever you gain a level that grants the Ability Score Improvement feature, add another level 1 Bard spell to your list of prepared spells.
+
+If another Warrior of Song feature gives you spells that you always have prepared, those spells don't count against the number of spells you can prepare with this feature, but those spells otherwise count as Bard spells for you.
+
+_**Changing Your Prepared Spells.**_ Whenever you gain a Monk level, you can replace one spell on your list with another level 1 Bard spell.
+
+_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Bard spells.
 
 _**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice.
 
-_**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Warrior of Song spells.
+_**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Bard spells.
 
 ### Level 6: Vanish
 
@@ -80,7 +86,7 @@ As part of your training in ancient arts of secret-keeping, you know how to make
 
 ### Level 11: ?
 
-?
+Once per turn, when you take the Attack action and make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of 1 action and a range of either touch or self.
 
 ### Level 17: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -121,7 +121,7 @@ You have been trained to act as a living compendium of ancient knowledge, and ca
 
 You have engaged in the study of magic song and incorporated it into your combat training. You gain the following benefits.
 
-_**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
+_**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _[The Royal Decree](ch-5-rhythmancy-spells.md#the-royal-decree)_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
 _**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell). The maximum number of Focus Points you can spend on casting a spell equals half your Monk level (round down).
 
@@ -149,7 +149,7 @@ As part of your training in ancient arts of secret-keeping, you know how to make
 
 ### Level 11: Songs of Travel
 
-You have learned secret songs that enable instantaneous long-distance travel. You always have the _Dimension Door_ and _Space Warp_ spells prepared. You can spend 5 Focus Points to cast either spell once without any Material components. Once you cast each spell using Focus Points, you regain the ability to do so when you finish a Long Rest.
+You have learned secret songs that enable instantaneous long-distance travel. You always have the _Dimension Door_ and _[Space Warp](ch-5-rhythmancy-spells.md#space-warp)_ spells prepared. You can spend 5 Focus Points to cast either spell once without any Material components. Once you cast each spell using Focus Points, you regain the ability to do so when you finish a Long Rest.
 
 ### Level 17: Music-Empowered Strikes
 
@@ -173,11 +173,11 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 
 | Ranger Level | Spells |
 |:------------:|:-------|
-| 3  | _The Hawk's Call_, _The Lost is Found_ |
-| 5  | _Song of Discovery_ |
-| 9  | _Wind's Requiem_ |
-| 13 | _Earth God's Lyric_ |
-| 17 | _Song of Healing_ |
+| 3  | _[The Hawk's Call](ch-5-rhythmancy-spells.md#the-hawks-call)_, _[The Lost is Found](ch-5-rhythmancy-spells.md#the-lost-is-found)_ |
+| 5  | _[No Stone Unturned](ch-5-rhythmancy-spells.md#no-stone-unturned)_ |
+| 9  | _[The Wind in My Sails](ch-5-rhythmancy-spells.md#the-wind-in-my-sails)_ |
+| 13 | _[The Sage of Earth's Calling](ch-5-rhythmancy-spells.md#the-sage-of-earths-calling)_ |
+| 17 | _[Healing Balm](ch-5-rhythmancy-spells.md#healing-balm)_ |
 
 ### Level 3: Music-Maker
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -68,15 +68,15 @@ _**Rhythmantic Focus.**_ You can cast spells you know from Warrior of Song featu
 
 _**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, replacing the Musical Instrument worth 1+ GP by lacing the music's magic seamlessly into your words.
 
-_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for spells you learn or cast using Warrior of Song features.
+_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Warrior of Song spells.
 
 _**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice.
 
-_**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Rhythmancy spells.
+_**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Warrior of Song spells.
 
 ### Level 6: ?
 
-?
+You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
 ### Level 11: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -76,7 +76,7 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 ### Level 6: Vanish
 
-You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
+As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
 ### Level 11: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -49,7 +49,7 @@ You have mastered unlocking hidden or lost ancient secrets. You always have the 
 _Impart Wisdom through Ancient Melody_
 
 > Time passes, people move, like a river's flow, it never ends. A childish mind will turn to noble ambition. Young love will become deep affection. The clear water's surface reflects growth. Now listen to the serenade of water and reflect upon yourself.
-> 
+>
 > — Sheik, _The Legend of Zelda: Ocarina of Time_
 
 Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information, often encoded within rhythmantic compositions and poems, under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
@@ -64,11 +64,11 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**Ancient Training.**_ Choose one level 1 Rhythmancy spell. You always have the selected spell prepared. Whenever you gain a Monk level, you can replace this spell with another level 1 Rhythmancy spell.
 
-_**Rhythmantic Focus.**_ You can cast Rhythmancy spells you have prepared by spending a number of Focus Points equal to twice the spell's level.
+_**Rhythmantic Focus.**_ You can cast spells you know from Warrior of Song features, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level.
 
 _**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, replacing the Musical Instrument worth 1+ GP by lacing the music's magic seamlessly into your words.
 
-_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for Rhythmancy spells you cast using this feature.
+_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for spells you learn or cast using Warrior of Song features.
 
 _**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -34,6 +34,32 @@ You can channel your song to temporarily boost the power of your rhythmantic mag
 
 You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. When you cast _Legend Lore_ using Rhythmancy Points, the casting time is 1 action, and you replace its Material component requirements with an instrument worth at least 1 GP.
 
+## Monk
+
+At level 3, a Monk gains the choice of a subclass. The following option is made available to you when making that choice: the Warrior of Song.
+
+### Warrior of Song
+
+_Impart Wisdom through Ancient Melody_
+
+?
+
+#### Level 3: ?
+
+?
+
+#### Level 6: ?
+
+?
+
+#### Level 11: ?
+
+?
+
+#### Level 17: ?
+
+?
+
 ## Ranger
 
 At 3rd level, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -1,20 +1,22 @@
 # Chapter 3: Rhythmancy Classes
 
-This section includes new subclass options with abilities centered around the use of rhythmancy magic.
+This chapter presents new subclasses with abilities centered around the use of rhythmancy magic:
 
-## Bard
+- **College of Legends:** A Bard who enhances magic with musical performance
 
-At 3rd level, a Bard gains the choice of a subclass. The following option is made available to you when making that choice: the College of Legends.
+- **Warrior of Song:** A Monk imparting ancient knowledge through oral tradition
 
-### College of Legends
+- **Wild Composer:** A Ranger who crafts magical instruments to share the music of nature
+
+## College of Legends (Bard)
 
 Though all bards have the ability to learn rhythmancy spells, practitioners of the College of Legends have built entire careers out of unlocking the magic sealed within these songs. These maestros are often sought out as teachers to aid new students in their rhythmantic studies, passing on what they learned from their own masters of the craft.
 
-#### Legendary Recall
+### Legendary Recall
 
 You have extensively pored through history books and sought out hidden knowledge of ancient heroes. You gain Proficiency in two skills of your choice from the following list: Arcana, History, Nature, or Religion. Additionally, when you make an Intelligence check, you can expend one use of Bardic Inspiration; roll the Bardic Inspiration die, and add the number rolled to the d20.
 
-#### Rhythmantic Savant
+### Rhythmantic Savant
 
 You have an innate understanding of the magic of music and how to wield it. You gain the following benefits.
 
@@ -26,45 +28,37 @@ _**Speed Training.**_ Whenever you learn a new song through rhythmantic training
 
 _**Abjurative Melody.**_ When you cast a level 1+ Rhythmancy spell targeting one or more creatures, in addition to the spell's normal effects, you can choose to grant any such targets a number of Temporary Hit Points equal to the spell level.
 
-#### Level 6: Inner Song
+### Level 6: Inner Song
 
 You can channel your song to temporarily boost the power of your rhythmantic magic. At the end of a Long Rest, you can expend one use of Bardic Inspiration to roll a Bardic Inspiration die and gain a number of temporary Rhythmancy Points equal to the number rolled. While you have these temporary Rhythmancy Points, they can be spent to cast or learn spells as if they were normal Rhythmancy Points, but they don't count toward your total number of Rhythmancy Points to determine the level of Rhythmancy spell you can cast or learn. Unspent temporary Rhythmancy Points from this feature disappear after you finish your next Long Rest.
 
-#### Level 14: Legendary Secrets
+### Level 14: Legendary Secrets
 
 You have mastered unlocking hidden or lost ancient secrets. You always have the _Legend Lore_ spell prepared. When you cast _Legend Lore_ using Rhythmancy Points, the casting time is 1 action, and you replace its Material component requirements with an instrument worth at least 1 GP.
 
-## Monk
-
-At level 3, a Monk gains the choice of a subclass. The following option is made available to you when making that choice: the Warrior of Song.
-
-### Warrior of Song
+## Warrior of Song (Monk)
 
 _Impart Wisdom through Ancient Melody_
 
 ?
 
-#### Level 3: ?
+### Level 3: ?
 
 ?
 
-#### Level 6: ?
+### Level 6: ?
 
 ?
 
-#### Level 11: ?
+### Level 11: ?
 
 ?
 
-#### Level 17: ?
+### Level 17: ?
 
 ?
 
-## Ranger
-
-At 3rd level, a Ranger gains the choice of a subclass. The following option is made available to you when making that choice: the Wild Composer.
-
-### Wild Composer
+## Wild Composer (Ranger)
 
 > You know there's rhythm all around us: the waves break in rhythm, people walk in rhythm, people breathe in rhythm, too. People work in rhythm! The whole world is made up of rhythm.
 >
@@ -72,11 +66,11 @@ At 3rd level, a Ranger gains the choice of a subclass. The following option is m
 
 Rangers who walk the path of the Wild Composer are drawn to the innate music present in the natural world. They revel in the melody of leaves rustling in the wind like chimes, and play along as woodpeckers drum a steady beat on tall steadfast trees. To these adventurers, the wild itself has a breath and cadence that grants those who can hear it great wisdom.
 
-#### Wild Composer Spells
+### Wild Composer Spells
 
 When you reach a Ranger level specified in the Wild Composer Spells table, you thereafter always have the listed spells prepared.
 
-##### Wild Composer Spells
+#### Wild Composer Spells
 
 | Ranger Level | Spells |
 |:------------:|:-------|
@@ -86,7 +80,7 @@ When you reach a Ranger level specified in the Wild Composer Spells table, you t
 | 13 | _Earth God's Lyric_ |
 | 17 | _Song of Healing_ |
 
-#### Music-Maker
+### Music-Maker
 
 You are in sync with the music of the wilds, allowing you to direct nature's song into musical instruments. You gain the following benefits.
 
@@ -100,19 +94,19 @@ An **Instrument of the Wild** you create contains a number of charges equal to t
 
 You regain the ability to craft an **Instrument of the Wild** using this feature after you finish a Long Rest. You can maintain the magical properties in a number of **Instruments of the Wild** equal to the highest level Ranger spell you know. If you craft an **Instrument of the Wild** beyond your limit, one such instrument of your choice loses all of its magical properties, becoming a mundane version of that instrument.
 
-#### Level 7: Rhythm of the World
+### Level 7: Rhythm of the World
 
 Your connection to the world's secret song strengthens. While you are Attuned to an **Instrument of the Wild**, your Rhythmancy spells gain a +1 to their attack rolls and total damage rolls, and when you cast a level 1+ Rhythmancy spell, you can expend one of the instrument's charges to cast the spell at one level higher than the original spell level; for example, casting a level 1 Rhythmancy spell and expending a charge would cast that spell at level 2.
 
 Additionally, you gain the ability to tap into the music of an unfamiliar environment and learn its underlying structure. When you cast _The Lost is Found_, for the spell's duration or until you leave the same environment you were in when casting the spell, the environment is considered to be your favored terrain, granting you Expertise in Intelligence and Wisdom checks you make related to the terrain.
 
-#### Level 11: Song of Leaf and Claw
+### Level 11: Song of Leaf and Claw
 
 Your ear for the songs of the natural world allows you to channel your magic through that musical structure. If you prepare any of the following Ranger spells, they are also considered to be Rhythmancy spells: _Animal Friendship_, _Beast Bond_, _Locate Animals or Plants_, _Speak with Animals_, and _Speak with Plants_. If you cast one of these spells using Rhythmancy Points or **Instrument of the Wild** charges, the Rhythmancy Point and instrument charge cost is reduced by 1.
 
 In addition, when you cast a Rhythmancy spell with a casting time of 1 action, you can make a melee or ranged weapon attack as a Bonus Action.
 
-#### Level 15: World Strider
+### Level 15: World Strider
 
 You recall every tree you have encountered, and can travel through the world's root systems to be reunited with them at a moment's notice. You always have the _Tree Stride_ spell prepared, and you can cast it by expending a level 4+ spell slot. Starting at level 17, you always have the _Transport via Plants_ spell prepared, and you can cast it by expending a level 5+ spell slot.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -40,11 +40,29 @@ You have mastered unlocking hidden or lost ancient secrets. You always have the 
 
 _Impart Wisdom through Ancient Melody_
 
-?
+> Time passes, people move, like a river's flow, it never ends. A childish mind will turn to noble ambition. Young love will become deep affection. The clear water's surface reflects growth. Now listen to the serenade of water and reflect upon yourself.
+> 
+> — Sheik, _The Legend of Zelda: Ocarina of Time_
 
-### Level 3: ?
+Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information, often encoded within rhythmantic compositions and poems, under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
 
-?
+### Level 3: Keeper of Secrets
+
+You have been trained to act as a living compendium of ancient knowledge, and can recite it on command. You gain Proficiency in a skill of your choice from the following list: Arcana, History, Nature, or Religion. You also have Expertise in the chosen skill. Whenever you finish a Long Rest, you can replace the selected skill with another skill of your choice from the above list, as you study your long memory and resurface other ancient secrets of song.
+
+### Level 3: Rhythmancy Warrior
+
+You have engaged in the study of magic song and incorporated it into your combat training. You gain the following benefits.
+
+_**Ancient Training.**_ Choose one level 1 Rhythmancy spell. You always have the selected spell prepared. Whenever you gain a Monk level, you can replace this spell with another level 1 Rhythmancy spell.
+
+_**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, replacing the Musical Instrument worth 1+ GP by lacing the music's magic seamlessly into your words.
+
+_**Spellcasting Ability.**_ Wisdom is your spellcasting ability for Rhythmancy spells you cast using this feature.
+
+_**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice.
+
+_**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Rhythmancy spells.
 
 ### Level 6: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -123,7 +123,9 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _[The Royal Decree](ch-5-rhythmancy-spells.md#the-royal-decree)_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell). The maximum number of Focus Points you can spend on casting a spell equals half your Monk level (round down).
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can spend additional Focus Points to increase the level of a Bard spell that you cast, provided that the spell has an enhanced effect at a higher level. The spell's level increases by 1 for each additional Focus Point you spend.
+
+The maximum number of Focus Points you can spend to cast a spell in this way (including its base Focus Point cost and any additional points you spend to increase its level) equals half your Monk level (round down).
 
 _**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,7 +64,7 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. You cannot cast a level 4+ spell using Focus Points.
+_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. The maximum amount of Focus Points you can spend for casting a spell, including casting it at a higher level, equals your Monk level divided by 3 (round down).
 
 _**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose one level 1 spell from the Bard spell list.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,7 +64,7 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast your Bard spells at higher levels at a cost of 1 Focus Point per level increase, but the maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell), but the maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
 
 _**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -52,7 +52,7 @@ _Impart Wisdom through Ancient Melody_
 >
 > — Sheik, _The Legend of Zelda: Ocarina of Time_
 
-Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information, often encoded within rhythmantic compositions and poems, under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
+Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information—often encoded within rhythmantic compositions and poems—under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
 
 ### Level 3: Keeper of Secrets
 
@@ -66,7 +66,7 @@ _**Ancient Training.**_ Choose one level 1 Rhythmancy spell. You always have the
 
 _**Rhythmantic Focus.**_ You can cast spells you know from Warrior of Song features, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level.
 
-_**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, replacing the Musical Instrument worth 1+ GP by lacing the music's magic seamlessly into your words.
+_**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
 _**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Warrior of Song spells.
 
@@ -74,7 +74,7 @@ _**Instrument Training.**_ You gain Proficiency with a Musical Instrument of you
 
 _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Warrior of Song spells.
 
-### Level 6: ?
+### Level 6: Vanish
 
 You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,38 +64,13 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. To determine the maximum number of Focus Points you can spend at once to cast a spell, including casting a spell at a higher level, see the Focus Point Spell Level column of the Warrior of Song Rhythmancy table.
-
-#### Warrior of Song Rhythmancy
-
-| Monk Level | Prepared Spells | Focus Point Spell Level |
-|:----------:|:---------------:|:-----------------------:|
-| 3  | 3  | 1 |
-| 4  | 4  | 1 |
-| 5  | 4  | 1 |
-| 6  | 4  | 2 |
-| 7  | 5  | 2 |
-| 8  | 6  | 2 |
-| 9  | 6  | 2 |
-| 10 | 7  | 2 |
-| 11 | 8  | 2 |
-| 12 | 8  | 2 |
-| 13 | 9  | 3 |
-| 14 | 10 | 3 |
-| 15 | 10 | 3 |
-| 16 | 11 | 3 |
-| 17 | 11 | 3 |
-| 18 | 11 | 3 |
-| 19 | 12 | 3 |
-| 20 | 13 | 3 |
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point.
 
 _**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 
-The number of spells on your list increases as you gain Monk levels, as shown in the Prepared Spells column of the Warrior of Song Rhythmancy table. Whenever that number increases, choose additional Bard spells until the number of spells on your list matches the number in the Warrior of Song Rhythmancy table. The chosen spells must be of a level no higher than what's shown in the table's Focus Point Spell Level column for your level. For example, if you're a level 7 Monk, your list of prepared spells can include five Bard spells of level 1 or 2 in any combination.
-
 If another Warrior of Song feature gives you spells that you always have prepared, those spells don't count against the number of spells you can prepare with this feature, but those spells otherwise count as Bard spells for you.
 
-_**Changing Your Prepared Spells.**_ Whenever you gain a Monk level, you can replace one spell on your list with another Bard spell of an eligible level.
+_**Changing Your Prepared Spells.**_ Whenever you gain a Monk level, you can replace one spell on your list with another level 1 Bard spell.
 
 _**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Bard spells.
 
@@ -105,7 +80,7 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 ### Level 6: Vanish
 
-As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
+As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared and can cast it for 1 Focus Point. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
 ### Level 11: Song-Empowered Strikes
 
@@ -113,7 +88,8 @@ You have learned how to weave arcane effects into your attacks. Once per turn, w
 
 ### Level 17: ?
 
-?
+You always have the _Dimension Door_ and _Teleportation Circle_ spells prepared.
+You can spend 5 Focus Points to cast either spell without any Material components. Once you cast either spell using Focus Points, you regain the ability to do so when you finish a Long Rest. You can also cast these spells normally using a spell slot of the appropriate level.
 
 ## Wild Composer (Ranger)
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -78,6 +78,12 @@ _**Instrument Training.**_ You gain Proficiency with a Musical Instrument of you
 
 _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Focus for your Bard spells.
 
+### Level 6: Shared Story
+
+When you find a worthy ally, you can impart a portion of your wisdom to aid them on their quest. As a Magic action, you can expend one Focus Point and touch a willing creature to grant it the ability to cast one Rhythmancy spell of your choice that you have prepared. It can cast this spell by expending the required number of your Focus Points, or by using a spell slot of the appropriate level or sufficient Rhythmancy Points it possesses. The creature must be on the same plane of existence as you to cast one of your spells in this manner. The spell uses your spellcasting ability and Proficiency Bonus when the target casts it.
+
+This effect lasts until the creature either casts your spell or finishes a Long Rest. You can also end the effect at any time (no action required).
+
 ### Level 6: Vanish
 
 As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared and can cast it by spending 1 Focus Point. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
@@ -92,8 +98,7 @@ You have learned a secret song that enables instantaneous long-distance travel. 
 
 ### Level 17: ?
 
-You always have the _Dimension Door_ and _Teleportation Circle_ spells prepared.
-You can spend 5 Focus Points to cast either spell without any Material components. Once you cast either spell using Focus Points, you regain the ability to do so when you finish a Long Rest. You can also cast these spells normally using a spell slot of the appropriate level.
+You always have the _Dimension Door_ and _Teleportation Circle_ spells prepared. You can spend 5 Focus Points to cast either spell once without any Material components. Once you cast each spell using Focus Points, you regain the ability to do so when you finish a Long Rest.
 
 ## Wild Composer (Ranger)
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,15 +64,38 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. The maximum amount of Focus Points you can spend for casting a spell, including casting it at a higher level, equals your Monk level divided by 3 (round down).
+_**Musical Mind.**_ You can cast spells you have prepared, including Rhythmancy songs, by spending a number of Focus Points equal to the spell's level. To determine the maximum number of Focus Points you can spend at once to cast a spell, including casting a spell at a higher level, see the Focus Point Spell Level column of the Warrior of Song Rhythmancy table.
 
-_**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose one level 1 spell from the Bard spell list.
+#### Warrior of Song Rhythmancy
 
-Whenever you gain a level that grants the Ability Score Improvement feature, add another Bard spell to your list of prepared spells. The chosen spell must be of a level for which you have sufficient Focus Points.
+| Monk Level | Prepared Spells | Focus Point Spell Level |
+|:----------:|:---------------:|:-----------------------:|
+| 3  | 3  | 1 |
+| 4  | 4  | 1 |
+| 5  | 4  | 1 |
+| 6  | 4  | 2 |
+| 7  | 5  | 2 |
+| 8  | 6  | 2 |
+| 9  | 6  | 2 |
+| 10 | 7  | 2 |
+| 11 | 8  | 2 |
+| 12 | 8  | 2 |
+| 13 | 9  | 3 |
+| 14 | 10 | 3 |
+| 15 | 10 | 3 |
+| 16 | 11 | 3 |
+| 17 | 11 | 3 |
+| 18 | 11 | 3 |
+| 19 | 12 | 3 |
+| 20 | 13 | 3 |
+
+_**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
+
+The number of spells on your list increases as you gain Monk levels, as shown in the Prepared Spells column of the Warrior of Song Rhythmancy table. Whenever that number increases, choose additional Bard spells until the number of spells on your list matches the number in the Warrior of Song Rhythmancy table. The chosen spells must be of a level no higher than what's shown in the table's Focus Point Spell Level column for your level. For example, if you're a level 7 Monk, your list of prepared spells can include five Bard spells of level 1 or 2 in any combination.
 
 If another Warrior of Song feature gives you spells that you always have prepared, those spells don't count against the number of spells you can prepare with this feature, but those spells otherwise count as Bard spells for you.
 
-_**Changing Your Prepared Spells.**_ Whenever you gain a Monk level, you can replace one spell on your list with another level 1 Bard spell.
+_**Changing Your Prepared Spells.**_ Whenever you gain a Monk level, you can replace one spell on your list with another Bard spell of an eligible level.
 
 _**Spellcasting Ability.**_ Wisdom is your spellcasting ability for your Bard spells.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -56,6 +56,8 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**Ancient Training.**_ Choose one level 1 Rhythmancy spell. You always have the selected spell prepared. Whenever you gain a Monk level, you can replace this spell with another level 1 Rhythmancy spell.
 
+_**Rhythmantic Focus.**_ You can cast Rhythmancy spells you have prepared by spending a number of Focus Points equal to twice the spell's level.
+
 _**Word of the Monarchs.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, replacing the Musical Instrument worth 1+ GP by lacing the music's magic seamlessly into your words.
 
 _**Spellcasting Ability.**_ Wisdom is your spellcasting ability for Rhythmancy spells you cast using this feature.

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -84,9 +84,9 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared. You can cast it once without spending Focus Points, and you regain the ability to do so when you finish a Long Rest. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
-### Level 11: ?
+### Level 11: Song-Empowered Strikes
 
-Once per turn, when you take the Attack action and make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of 1 action and a range of either touch or self.
+You have learned how to weave arcane effects into your attacks. Once per turn, when you make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of an action and a range of either touch or self. You can't cast a spell in this way if you've already cast a level 1+ spell on the current turn, nor can you cast a level 1+ spell on this turn after casting a spell in this way.
 
 ### Level 17: ?
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -66,7 +66,7 @@ _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority gr
 
 _**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast your Bard spells at higher levels at a cost of 1 Focus Point per level increase, but the maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
 
-_**Prepared Spells of Level 1+.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
+_**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 
 If another Warrior of Song feature gives you spells that you always have prepared, those spells don't count against the number of spells you can prepare with this feature, but those spells otherwise count as Bard spells for you.
 
@@ -82,23 +82,19 @@ _**Spellcasting Focus.**_ You can use a Musical Instrument as a Spellcasting Foc
 
 When you find a worthy ally, you can impart a portion of your wisdom to aid them on their quest. As a Magic action, you can expend one Focus Point and touch a willing creature to grant it the ability to cast one Rhythmancy spell of your choice that you have prepared. It can cast this spell by expending the required number of your Focus Points, or by using a spell slot of the appropriate level or sufficient Rhythmancy Points it possesses. The creature must be on the same plane of existence as you to cast one of your spells in this manner. The spell uses your spellcasting ability and Proficiency Bonus when the target casts it.
 
-This effect lasts until the creature either casts your spell or finishes a Long Rest. You can also end the effect at any time (no action required).
+This effect lasts until the creature casts your spell. You can also end the effect at any time (no action required).
 
 ### Level 6: Vanish
 
 As part of your training in ancient arts of secret-keeping, you know how to make a quick exit. You always have the _Misty Step_ spell prepared and can cast it by spending 1 Focus Point. Additionally, you can choose to cast _Misty Step_ as a Reaction triggered when a creature you can see hits you with an attack, causing the attack to miss.
 
-### Level 11: Song-Empowered Strikes
+### Level 11: Songs of Travel
+
+You have learned secret songs that enable instantaneous long-distance travel. You always have the _Dimension Door_ and _Space Warp_ spells prepared. You can spend 5 Focus Points to cast either spell once without any Material components. Once you cast each spell using Focus Points, you regain the ability to do so when you finish a Long Rest.
+
+### Level 17: Music-Empowered Strikes
 
 You have learned how to weave arcane effects into your attacks. Once per turn, when you make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of an action and a range of either touch or self. You can't cast a spell in this way if you've already cast a level 1+ spell on the current turn, nor can you cast a level 1+ spell on this turn after casting a spell in this way.
-
-### Level 11: Space Warp
-
-You have learned a secret song that enables instantaneous long-distance travel. You always have the _Space Warp_ spell prepared and can cast it by spending 3 Focus Points.
-
-### Level 17: ?
-
-You always have the _Dimension Door_ and _Teleportation Circle_ spells prepared. You can spend 5 Focus Points to cast either spell once without any Material components. Once you cast each spell using Focus Points, you regain the ability to do so when you finish a Long Rest.
 
 ## Wild Composer (Ranger)
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -52,7 +52,7 @@ _Impart Wisdom through Ancient Melody_
 >
 > — Sheik, _The Legend of Zelda: Ocarina of Time_
 
-Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information—often encoded within rhythmantic compositions and poems—under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world.
+Within most monasteries, one Monk chooses to train as a Warrior of Song, acting as the keeper of the organization's sacred techniques and communal knowledge. This individual knows when to keep such information—often encoded within rhythmantic compositions and poems—under their careful watch, and when to share this knowledge with heroes who would use it to strike down the great evils threatening the order of the world. Eventually this includes the knowledge of magical teleportation.
 
 ### Level 3: Keeper of Secrets
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -64,7 +64,7 @@ You have engaged in the study of magic song and incorporated it into your combat
 
 _**The Royal Decree.**_ Among the secrets you keep is a deep-seated authority granted to your monk sect by ancient royal families. You know _The Royal Decree_ spell. You can spend one Focus Point to cast it without any Verbal or Material components, bypassing the Musical Instrument requirement by lacing the music's magic seamlessly into your words.
 
-_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell), but the maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
+_**Musical Mind.**_ You can cast level 1 Bard spells you have prepared, including Rhythmancy songs, by spending 1 Focus Point. You can cast Bard spells you have prepared at higher levels at a cost of 1 Focus Point per level increase (in addition to the initial Focus Point cost of casting the spell). The maximum number of Focus Points you spend on casting a spell cannot exceed half your Monk level (round down).
 
 _**Prepared Level 1 Spells.**_ You prepare the list of level 1 spells that are available for you to cast with this feature. To start, choose three level 1 Bard spells.
 

--- a/docs/ch-3-rhythmancy-classes.md
+++ b/docs/ch-3-rhythmancy-classes.md
@@ -153,7 +153,7 @@ You have learned secret songs that enable instantaneous long-distance travel. Yo
 
 ### Level 17: Music-Empowered Strikes
 
-You have learned how to weave arcane effects into your attacks. Once per turn, when you make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of an action and a range of either touch or self. You can't cast a spell in this way if you've already cast a level 1+ spell on the current turn, nor can you cast a level 1+ spell on this turn after casting a spell in this way.
+You have learned how to weave arcane effects into your attacks. Once per turn, when you make an Unarmed Strike, in place of the normal options for its effect, you can cast a spell you have prepared. The spell must have a casting time of an action and a range of either touch or self.
 
 ## Wild Composer (Ranger)
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -9,14 +9,14 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | Level | Spell | School | Class | Special |
 |:-----:|:------|:-------|:------|:--------|
 | cantrip | _[Ballad of the Dreamer](#ballad-of-the-dreamer)_ | Abjuration/Rhythmancy | Bard | — |
-| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard | — |
-| cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | — |
-| 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard | |
-| 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | — |
-| 1 | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R |
-| 1 | _[The Oncoming Storm](#the-oncoming-storm)_ | Evocation/Rhythmancy | Bard | Concentration |
-| 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
-| 1 | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard | — |
+| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
+| cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard, Monk (Warrior of Song) | — |
+| 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard, Monk (Warrior of Song) | |
+| 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard, Monk (Warrior of Song) | — |
+| 1 | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Monk (Warrior of Song), Ranger (Wild Composer) | C, R |
+| 1 | _[The Oncoming Storm](#the-oncoming-storm)_ | Evocation/Rhythmancy | Bard, Monk (Warrior of Song) | Concentration |
+| 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard, Monk (Warrior of Song) | — |
+| 1 | _[Summoning of the Scarecrow](#summoning-of-the-scarecrow)_ | Conjuration/Rhythmancy | Bard, Monk (Warrior of Song) | — |
 | 2 | _[Duet of Restoration](#duet-of-restoration)_ | Evocation/Rhythmancy | Bard | D |
 | 2 | _[An Empty Shell](#an-empty-shell)_ | Conjuration/Rhythmancy | Bard | — |
 | 2 | _[No Stone Unturned](#no-stone-unturned)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R, M |
@@ -106,7 +106,7 @@ Until the spell ends, an aura of spectral water and healing energy surrounds you
 
 ### _The Curse, Reversed_
 
-_Level 1 Abjuration/Rhythmancy (Bard)_
+_Level 1 Abjuration/Rhythmancy (Bard), Monk (Warrior of Song)_
 
 **Casting Time:** 1 minute\
 **Range:** Touch\
@@ -158,7 +158,7 @@ A shell based on your form vanishes the next time you cast this spell, unless yo
 
 ### _Equine Tribute_
 
-_Level 1 Conjuration/Rhythmancy (Bard)_
+_Level 1 Conjuration/Rhythmancy (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** 1 minute\
 **Range:** 30 feet\
@@ -177,7 +177,7 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your c
 
 ### _The Hawk's Call_
 
-_Evocation/Rhythmancy Cantrip (Bard)_
+_Evocation/Rhythmancy Cantrip (Bard, Ranger (Wild Composer))_
 
 **Casting Time:** Action\
 **Range:** 30 feet\
@@ -222,7 +222,7 @@ Manipulating gravity and mass in this manner takes a physical toll on your body.
 
 ### _The Lost is Found_
 
-_Level 1 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
+_Level 1 Divination/Rhythmancy (Bard, Monk (Warrior of Song), Ranger (Wild Composer))_
 
 **Casting Time:** 1 minute or Ritual\
 **Range:** Self\
@@ -291,7 +291,7 @@ You perform a tune that disrupts any concealing magic in the vicinity. Until the
 
 ### _The Oncoming Storm_
 
-_Level 1 Evocation/Rhythmancy (Bard)_
+_Level 1 Evocation/Rhythmancy (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** 1 minute\
 **Range:** 120 feet (1 mile if cast outdoors)\
@@ -411,7 +411,7 @@ If you are successfully forced to the ground against your will for 1 minute or l
 
 ### _Song of Time_
 
-_Level 1 Abjuration/Rhythmancy (Bard)_
+_Level 1 Abjuration/Rhythmancy (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** Action\
 **Range:** Self\
@@ -502,7 +502,7 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or hi
 
 ### _Summoning of the Scarecrow_
 
-_Level 1 Conjuration/Rhythmancy (Bard)_
+_Level 1 Conjuration/Rhythmancy (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** 1 minute\
 **Range:** 120 feet\

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -35,7 +35,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 4 | _[The Sage of Earth's Calling](#the-sage-of-earths-calling)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | M |
 | 4 | _[The Sage of Wind's Beckoning](#the-sage-of-winds-beckoning)_ | Evocation/Rhythmancy | Bard | M |
 | 4 | _[Soulful Croak](#soulful-croak)_ | Necromancy/Rhythmancy | Bard | M |
-| 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard | R, M |
+| 4 | _[Space Warp](#space-warp)_ | Conjuration/Rhythmancy | Bard, Monk (Warrior of Song) | R, M |
 | 5 | _[Concerto No. 2 in G minor, "Ripples of the Current"](#concerto-no-2-in-g-minor-ripples-of-the-current)_ | Abjuration/Rhythmancy | Bard | M |
 | 5 | _[Healing Balm](#healing-balm)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
@@ -349,7 +349,7 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 7 or hi
 
 ### _The Royal Decree_
 
-_Enchantment/Rhythmancy Cantrip (Bard)_
+_Enchantment/Rhythmancy Cantrip (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** Action\
 **Range:** 10 feet\
@@ -476,7 +476,7 @@ On a successful save, or if the Charmed condition on the undead creature ends, t
 
 ### _Space Warp_
 
-_Level 4 Conjuration/Rhythmancy (Bard)_
+_Level 4 Conjuration/Rhythmancy (Bard, Monk (Warrior of Song))_
 
 **Casting Time:** 10 minutes or Ritual\
 **Range:** 10 feet\

--- a/docs/ch-6-rhythmancy-magic-items.md
+++ b/docs/ch-6-rhythmancy-magic-items.md
@@ -8,9 +8,9 @@ This document introduces a new category of magic items: instruments.
 
 ### Instruments
 
-Magic instruments function as regular musical instruments, but are imbued with additional arcane properties. Often such instruments provide access to rhythmantic songs, or enhance a rhythmancer's existing abilities.
+Magic Instruments function as regular musical instruments, but are imbued with additional arcane properties. Often such instruments provide access to rhythmantic songs, or enhance a rhythmancer's existing abilities.
 
-When used in worlds and settings where "instrument" does not exist as a magic item category, such magic items also count as wondrous items. Similarly, a wondrous item that can function as a musical instrument, such as the **Pipes of the Sewers**, also counts as an instrument magic item, as long as the wielder meets the item's proficiency requirements to play it.
+When used in worlds and settings where "Instrument" does not exist as a magic item category, such magic items also count as Wondrous Items. Similarly, a Wondrous Item that can function as a musical instrument, such as the **Pipes of the Sewers**, also counts as an Instrument magic item, as long as the wielder meets the item's proficiency requirements to play it.
 
 ##### Rhythmancy Magic Items
 
@@ -33,13 +33,13 @@ An Instrument of the Wild contains one or more spells based on its number of cha
 
 ##### Instrument of the Wild Rarity
 
-| Charges | Rhythmancy Spell    | Rarity    |
-|:-------:|:--------------------|:----------|
-| 1       | _The Lost is Found_ | Common    |
-| 2       | _Song of Discovery_ | Uncommon  |
-| 3       | _Wind's Requiem_    | Rare      |
-| 4       | _Earth God's Lyric_ | Very Rare |
-| 5       | _Song of Healing_   | Legendary |
+| Charges | Rhythmancy Spell    | Rarity |
+|:-------:|:--------------------|:-------|
+| 1       | _[The Lost is Found](ch-5-rhythmancy-spells.md#the-lost-is-found)_ | Common |
+| 2       | _[No Stone Unturned](ch-5-rhythmancy-spells.md#no-stone-unturned)_ | Uncommon |
+| 3       | _[The Wind in My Sails](ch-5-rhythmancy-spells.md#the-wind-in-my-sails)_ | Rare |
+| 4       | _[The Sage of Earth's Calling](ch-5-rhythmancy-spells.md#the-sage-of-earths-calling)_ | Very Rare |
+| 5       | _[Healing Balm](ch-5-rhythmancy-spells.md#healing-balm)_   | Legendary |
 
 ### Maracas of Holding
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ This document includes a list of class options, feats, spells, and magic items u
 ### [Chapter 3: Rhythmancy Classes](ch-3-rhythmancy-classes.md)
 
 - [Bard Subclass: College of Legends](ch-3-rhythmancy-classes.md#college-of-legends)
+- [Monk Subclass: Warrior of Song](ch-3-rhythmancy-classes.md#warrior-of-song)
 - [Ranger Subclass: Wild Composer](ch-3-rhythmancy-classes.md#wild-composer)
 
 ### [Chapter 4: Rhythmancy Feats](ch-4-rhythmancy-feats.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,9 +12,9 @@ This document includes a list of class options, feats, spells, and magic items u
 
 ### [Chapter 3: Rhythmancy Classes](ch-3-rhythmancy-classes.md)
 
-- [Bard Subclass: College of Legends](ch-3-rhythmancy-classes.md#college-of-legends)
-- [Monk Subclass: Warrior of Song](ch-3-rhythmancy-classes.md#warrior-of-song)
-- [Ranger Subclass: Wild Composer](ch-3-rhythmancy-classes.md#wild-composer)
+- [College of Legends (Bard)](ch-3-rhythmancy-classes.md#college-of-legends-bard)
+- [Warrior of Song (Monk)](ch-3-rhythmancy-classes.md#warrior-of-song-monk)
+- [Wild Composer (Ranger)](ch-3-rhythmancy-classes.md#wild-composer-ranger)
 
 ### [Chapter 4: Rhythmancy Feats](ch-4-rhythmancy-feats.md)
 


### PR DESCRIPTION
- added Warrior of Song Monk:
  - Level 3: Keeper of Secrets:
    - Expertise in INT skill, swap 1/LR
  - Level 3: Rhythmancy Warrior:
    - Royal Decree cantrip, 1 FP to bypass VM components
    - three level 1 Rhythmancy spells, swap 1/Monk level
    - can use 1 FP to cast level 1 Bard/Rhythmancy spells and can upcast for +1 FP/level, max spend Monk/2
    - instrument proficiency and use as spellcasting focus
    - WIS spellcasting ability
  - Level 6: Shared Story:
    - Magic action + 1 FP + touch a creature to let them cast one of the Monk's spells by spending Monk FP (or their own resources), lasts until cast or Monk ends the effect
  - Level 6: Vanish:
    - _Misty Step_ always prepared, 1 FP to cast, can cast as a reaction to turn a hit into a miss
  - Level 11: Songs of Travel:
    - _Dimension Door_ and _Space Warp_ always prepared, 5 FP to cast bypassing Material components (1/day/spell)
  - Level 17: Music-Empowered Strikes:
    - can replace Unarmed Strike with touch/self action spell 1/turn (no other leveled spells on the same turn)
- added Monk to Rhythmancy spells: _The Royal Decree_, all level 1, and _Space Warp_
- adjusted Focus Point Rhythmancy rules (cost = feature's FP cost at same spell level)
- added anchor links for all mentions of Rhythmancy spells pointed at their main entries
- corrected spell names that have been updated