### PR TITLE
errata 2026-01-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-This project is a repository of information about rhythmancy, a school of magic based on musical performance. It includes mechanics for casting rhythmancy magic, some class and feat options for gaioning access to this magic, and spells and magic items that channel rhythmancy.
+This project is a repository of information about Rhythmancy, a Dungeons & Dragons 5th Edition school of magic based on musical performance. It includes mechanics for casting rhythmancy magic, some class and feat options for gaining access to this magic, and spells and magic items that channel rhythmancy.
 
 See https://mpanighetti.github.io/dnd5e-rhythmancy for a published browsable webpage. This repository is a GitHub-managed version of the published page. Feel free to contribute to this project by submitting issues or pull requests.
 

--- a/docs/ch-2-casting-rhythmancy-spells.md
+++ b/docs/ch-2-casting-rhythmancy-spells.md
@@ -8,9 +8,9 @@ Rhythmantic cantrips can be cast an unlimited number of times, regardless of fea
 
 ## Component Requirements
 
-All rhythmancy spells, in addition to normal spell slot usage and component requirements, include both a verbal component and a specific material component requirement of an instrument with a value of at least 1 gp. This instrument substitutes as your spellcasting focus when using rhythmantic magic. Instruments that are magic items also satisfy this material component requirement.
+All rhythmancy spells, in addition to normal spell slot usage and component requirements, include both a Verbal component and a specific Material component requirement of a Musical Instrument with a value of at least 1 GP. This instrument substitutes as your spellcasting focus when using rhythmantic magic. Instruments that are magic items also satisfy this material component requirement.
 
-Due to the inherently performative nature of rhythmancy, the requirements for both a verbal component and instrument cannot be bypassed with any class feature (such as a sorcerer's Subtle Spell metamagic option), trait, or any other ability, unless it specifically allows ignoring component requirements for rhythmancy magic.
+Due to the inherently performative nature of rhythmancy, the requirements for both a Verbal component and instrument cannot be bypassed with any class feature (such as a sorcerer's Subtle Spell metamagic option), trait, or any other ability, unless it specifically allows ignoring component requirements for rhythmancy magic.
 
 ## Spellcasting and Pact Magic
 
@@ -53,9 +53,9 @@ If the spell cannot be used with the feature's limitations, it cannot be learned
 Some rhythmancy songs are written to be performed by two musicians working together to create more powerful magic than they could accomplish on their own. Duets function like normal spells but come with additional requirements for the magic to be successfully linked between the two casters:
 
 - The rhythmancy spell performed by both casters must be the same.
-- Both performers must choose the same target when casting their spells.
-- Both casters must provide all required components and spell slots.
-- After the first spellcasting is begun, the partner's spell must begin before the first caster's next turn. To ensure synchrony, one partner could use the Ready Action so that their spell begins casting as a Reaction to the other partner starting their song.
+- Both performers must choose the same target or area of effect when casting their spells.
+- Both casters must provide all required components, spell slots, Rhythmancy Points, or other resources.
+- Once one performer starts casting the spell, the partner's spell must be cast before the first caster's next turn. To ensure synchrony, one partner could use the Ready Action so that their spell begins casting as a Reaction to the other partner starting their song.
 - Both casters must be able to hear each other during the entire casting times of the spells to ensure their performances remain in sync.
 
 If any of the above conditions are not met, both castings of the Duet spell fail. Otherwise, the spells grant their shared effect after both casters complete the required casting time.

--- a/docs/ch-4-rhythmancy-feats.md
+++ b/docs/ch-4-rhythmancy-feats.md
@@ -1,6 +1,6 @@
 # Chapter 4: Rhythmancy Feats
 
-This section presents a sampling of feats appropriate for a campaign featuring rhythmancy magic. If a feat has a prerequisite, you must meet that prerequisite to gain the feat. The **Rhythmancy Feat List** table lists the feats in this section along with the level at which they're available. The list is grouped by category.
+This section presents a sampling of feats appropriate for a campaign featuring rhythmantic magic. If a feat has a prerequisite, you must meet that prerequisite to gain the feat. The **Rhythmancy Feat List** table lists the feats in this section along with the level at which they're available. The list is grouped by category.
 
 ##### Rhythmancy Feat List
 
@@ -19,11 +19,11 @@ _General Feat (Prerequisite: Level 4+, Rhythmancy Initiate Feat)_
 
 Your extended practice in channeling rhythmantic energies has granted you additional control and power. You gain the following benefits.
 
-_**Two Rhythmancy Points.**_ You gain 2 Rhythmancy Points to spend on casting rhythmancy spells.
+_**Two Rhythmancy Points.**_ You gain 2 Rhythmancy Points to spend on casting Rhythmancy spells.
 
-_**Spells.**_ Choose either one level 2 rhythmancy spell or two level 1 rhythmancy spells. You always have that spell or spells prepared. You can cast your selection using Rhythmancy Points or any spell slots you have.
+_**Spells.**_ Choose either one level 2 Rhythmancy spell or two level 1 Rhythmancy spells. You always have that spell or spells prepared. You can cast your selection using Rhythmancy Points or any spell slots you have.
 
-_**Natural Performer.**_ Choose one of the following skills: Deception, Intimidation, Performance, or Persuasion. If you lack proficiency in the chosen skill, you gain proficiency in it, and if you already have proficiency in it, you gain Expertise in it.
+_**Natural Performer.**_ Choose one of the following skills: Deception, Intimidation, Performance, or Persuasion. If you lack Proficiency in the chosen skill, you gain Proficiency in it, and if you already have Proficiency in it, you gain Expertise in it.
 
 ### Rhythmancy Initiate
 
@@ -31,13 +31,13 @@ _Origin Feat_
 
 You've begun studying the magic of rhythmantic songs. You gain the following benefits.
 
-_**One Rhythmancy Point.**_ You gain 1 Rhythmancy Point to spend on casting rhythmancy spells.
+_**One Rhythmancy Point.**_ You gain 1 Rhythmancy Point to spend on casting Rhythmancy spells.
 
-_**One Cantrip.**_ You learn one rhythmancy cantrip of your choice.
+_**One Cantrip.**_ You learn one Rhythmancy cantrip of your choice.
 
-_**Level 1 Spell.**_ Choose a level 1 rhythmancy spell. You always have that spell prepared. You can cast it using Rhythmancy Points or any spell slots you have.
+_**Level 1 Spell.**_ Choose a level 1 Rhythmancy spell. You always have that spell prepared. You can cast it using Rhythmancy Points or any spell slots you have.
 
-_**Instrument Training.**_ You gain proficiency with a Musical Instrument of your choice. You can use such an instrument as a spellcasting focus for any spell you cast using Rhythmancy Points.
+_**Instrument Training.**_ You gain Proficiency with a Musical Instrument of your choice. You can use such an instrument as a spellcasting focus for any spell you cast using Rhythmancy Points.
 
 ---
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -9,7 +9,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | Level | Spell | School | Class | Special |
 |:-----:|:------|:-------|:------|:--------|
 | cantrip | _[Ballad of the Dreamer](#ballad-of-the-dreamer)_ | Abjuration/Rhythmancy | Bard | — |
-| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard | — |
+| cantrip | _[The Hawk's Call](#the-hawks-call)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | — |
 | 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard | |
 | 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | — |
@@ -177,7 +177,7 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your c
 
 ### _The Hawk's Call_
 
-_Evocation/Rhythmancy Cantrip (Bard)_
+_Evocation/Rhythmancy Cantrip (Bard, Ranger (Wild Composer))_
 
 **Casting Time:** Action\
 **Range:** 30 feet\
@@ -545,8 +545,6 @@ You attempt to restore the normal flow of time for a creature you can see within
 
 Any ongoing spell of level 5 or lower on the target that falls under one of the above criteria ends, similar to the effect of _Dispel Magic_; additionally, any valid spell for which you were originally the caster and any valid magical effect not caused by a spell ends. A creature magically displaced from their original time period is immediately returned to their era, and all magical aging is removed.
 
-[^⏳]: Source: _Explorer's Guide to Wildemount_
-
 ### _Concerto No. 3 in F minor, "Master of the Ages"_
 
 _Level 7 Conjuration/Rhythmancy (Bard)_
@@ -578,3 +576,5 @@ _**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 4 or hi
 ---
 
 [⬅️ Chapter 4: Rhythmancy Feats](ch-4-rhythmancy-feats.md) | [Home ⬆️](index.md) | [Chapter 6: Rhythmancy Magic Items ➡️](ch-6-rhythmancy-magic-items.md)
+
+[^⏳]: Source: _Explorer's Guide to Wildemount_


### PR DESCRIPTION
- ch-2-casting-rhythmancy-spells.md:
  - clarified Duet requirements (allowed for any resources for normal spellcasting rather than just spell slots, cleared up casting order of operations)
- ch-5-rhythmancy-spells.md:
  - added The Hawk's Call to Wild Composer spell list
  - moved Wildemount source anchor text to bottom of page
- README.md:
  - clarified game system
  - typo correction
- capitalized game mechanics