### PR TITLE
added Gathering of the Elements

### DIFF
--- a/docs/ch-1-learning-rhythmancy-spells.md
+++ b/docs/ch-1-learning-rhythmancy-spells.md
@@ -55,4 +55,4 @@ You must use the first option available to you based on your class levels, featu
 
 ---
 
-[Chapter 2: Casting Rhythmancy Spells ➡️](ch-2-casting-rhythmancy-spells.md) | [Home ⬆️](index.md)
+[Home ⬆️](index.md) | [Chapter 2: Casting Rhythmancy Spells ➡️](ch-2-casting-rhythmancy-spells.md)

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -187,17 +187,17 @@ _Level 1 Evocation/Rhythmancy (Bard)_
 
 You call the natural forces of the universe to your aid, summoning a mote of elemental energy from a distant realm and throwing it at a creature you can see within range. The target makes a Dexterity saving throw, taking damage and undergoing a secondary effect based on the plane of existence from which the mote originates on a failed save (you pick each time you cast this spell). On a successful save, it takes half the damage only and isn't subjected to the secondary effect.
 
-   _**Cloak of Night (Lower Planes).**_ The target takes 2d6 Necrotic damage and has Disadvantage on Wisdom saving throws until the end of its next turn.
+**Cloak of Night (Lower Planes).** The target takes 2d6 Necrotic damage and has Disadvantage on Wisdom saving throws until the end of its next turn.
 
-   _**The Forest for the Trees (Elemental Plane of Earth).**_ The target takes 2d6 Acid damage and has Disadvantage on ranged attacks until the end of its next turn.
+**The Forest for the Trees (Elemental Plane of Earth).** The target takes 2d6 Acid damage and has Disadvantage on ranged attacks until the end of its next turn.
 
-   _**The Icy Depths (Elemental Plane of Water).**_ The target takes 2d6 Cold damage and has Disadvantage on Strength saving throws until the end of its next turn.
+**The Icy Depths (Elemental Plane of Water).** The target takes 2d6 Cold damage and has Disadvantage on Strength saving throws until the end of its next turn.
 
-   _**Morning's Light (Upper Planes).**_ The target takes 2d6 Radiant damage and has Disadvantage on melee attacks until the end of its next turn.
+**Morning's Light (Upper Planes).** The target takes 2d6 Radiant damage and has Disadvantage on melee attacks until the end of its next turn.
 
-   _**Sabor de Fuego (Elemental Plane of Fire).**_ The target takes 2d6 Fire damage and starts burning.
+**Sabor de Fuego (Elemental Plane of Fire).** The target takes 2d6 Fire damage and starts burning.
 
-   _**The Spirit of the Wind (Elemental Plane of Air).**_ The target takes 2d6 Lightning damage and has Disadvantage on Dexterity saving throws until the end of its next turn.
+**The Spirit of the Wind (Elemental Plane of Air).** The target takes 2d6 Lightning damage and has Disadvantage on Dexterity saving throws until the end of its next turn.
 
 _**Using a Higher-Level Spell Slot.**_ You summon another mote for each spell slot level above 1. Each mote can originate from a different plane of existence you pick. A creature can be targeted only once by each casting of this spell.
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -13,6 +13,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | cantrip | _[The Royal Decree](#the-royal-decree)_ | Enchantment/Rhythmancy | Bard | — |
 | 1 | _[The Curse, Reversed](#the-curse-reversed)_ | Abjuration/Rhythmancy | Bard | |
 | 1 | _[Equine Tribute](#equine-tribute)_ | Conjuration/Rhythmancy | Bard | — |
+| 1 | _[Gathering of the Elements](#gathering-of-the-elements)_ | Evocation/Rhythmancy | Bard | — |
 | 1 | _[The Lost is Found](#the-lost-is-found)_ | Divination/Rhythmancy | Bard, Ranger (Wild Composer) | C, R |
 | 1 | _[The Oncoming Storm](#the-oncoming-storm)_ | Evocation/Rhythmancy | Bard | Concentration |
 | 1 | _[Song of Time](#song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
@@ -174,6 +175,31 @@ When you cast this spell and already have a companion, instead of making a new c
 If your companion is mistreated or harmed by you or any of your allies, or at their own discretion, they can choose to end their companionship to you, and you can similarly end this companionship at any time. If you already have a companion and target a new creature with this spell, the previous companionship ends. Otherwise, the companionship lasts until you or your companion dies.
 
 _**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your companion using a Spell Slot of 2nd-level or higher, they gain a number of Temporary Hit Points equal to five times the Spell Slot level.
+
+### _Gathering of the Elements_
+
+_Level 1 Evocation/Rhythmancy (Bard)_
+
+**Casting Time:** Action\
+**Range:** 30 feet\
+**Components:** V, S, M (a Musical Instrument worth 1+ GP)\
+**Duration:** Instantaneous
+
+You call the natural forces of the universe to your aid, summoning a mote of elemental energy from a distant realm and throwing it at a creature you can see within range. The target makes a Dexterity saving throw, taking damage and undergoing a secondary effect based on the plane of existence from which the mote originates on a failed save (you pick each time you cast this spell). On a successful save, it takes half the damage only and isn't subjected to the secondary effect.
+
+   _**Cloak of Night (Lower Planes).**_ The target takes 2d6 Necrotic damage and has Disadvantage on Wisdom saving throws until the end of its next turn.
+
+   _**The Forest for the Trees (Elemental Plane of Earth).**_ The target takes 2d6 Acid damage and has Disadvantage on ranged attacks until the end of its next turn.
+
+   _**The Icy Depths (Elemental Plane of Water).**_ The target takes 2d6 Cold damage and has Disadvantage on Strength saving throws until the end of its next turn.
+
+   _**Morning's Light (Upper Planes).**_ The target takes 2d6 Radiant damage and has Disadvantage on melee attacks until the end of its next turn.
+
+   _**Sabor de Fuego (Elemental Plane of Fire).**_ The target takes 2d6 Fire damage and starts burning.
+
+   _**The Spirit of the Wind (Elemental Plane of Air).**_ The target takes 2d6 Lightning damage and has Disadvantage on Dexterity saving throws until the end of its next turn.
+
+_**Using a Higher-Level Spell Slot.**_ You summon another mote for each spell slot level above 1. Each mote can originate from a different plane of existence you pick. A creature can be targeted only once by each casting of this spell.
 
 ### _The Hawk's Call_
 

--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -185,7 +185,7 @@ _Level 1 Evocation/Rhythmancy (Bard)_
 **Components:** V, S, M (a Musical Instrument worth 1+ GP)\
 **Duration:** Instantaneous
 
-You call the natural forces of the universe to your aid, summoning a mote of elemental energy from a distant realm and throwing it at a creature you can see within range. The target makes a Dexterity saving throw, taking damage and undergoing a secondary effect based on the plane of existence from which the mote originates on a failed save (you pick each time you cast this spell). On a successful save, it takes half the damage only and isn't subjected to the secondary effect.
+You call the natural forces of the universe to your aid, summoning a mote of elemental energy from a distant realm and throwing it at a creature you can see within range. The target makes a Dexterity saving throw. On a failed save, the target takes damage and is subjected to a secondary effect based on the plane of existence from which the mote originates (you pick each time you cast this spell). On a successful save, it takes half the damage only and isn't subjected to the secondary effect.
 
 **Cloak of Night (Lower Planes).** The target takes 2d6 Necrotic damage and has Disadvantage on Wisdom saving throws until the end of its next turn.
 

--- a/docs/ch-6-rhythmancy-magic-items.md
+++ b/docs/ch-6-rhythmancy-magic-items.md
@@ -56,4 +56,4 @@ The Maracas of Holding contain 3 charges. While you are Attuned to the Maracas o
 
 ---
 
-[⬅️ Chapter 5: Rhythmancy Spells](ch-5-rhythmancy-spells.md) | [Home ⬆️](index.md)
+[⬅️ Chapter 5: Rhythmancy Spells](ch-5-rhythmancy-spells.md) | [Home ⬆️](index.md) | [Rules Definitions ➡️](rules-definitions.md)

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -9,3 +9,7 @@
 The materials below are referenced under fair use exemption of the U.S. Copyright Law and are restricted from further use. These materials, including references to game mechanics, are not approved or endorsed by the copyright holders and do not constitute any license or agreement with the copyright holders.
 
 _Explorer's Guide to Wildemount_ © 2020 Wizards of the Coast LLC.
+
+---
+
+[⬅️ Rules Definitions](rules-definitions.md) | [Home ⬆️](index.md) | [Licensing ➡️](licensing.md)

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -7,3 +7,7 @@ _Rhythmancy: The Magic of Music_ is © 2022 Mario Panighetti. This work is licen
 _[System Reference Document 5.1](https://dndbeyond.com/srd)_ ("SRD 5.1") © 2016 Wizards of the Coast LLC. Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
 
 _[System Reference Document 5.2.1](https://www.dndbeyond.com/srd)_ ("SRD 5.2.1") © 2025 Wizards of the Coast LLC. Licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode).
+
+---
+
+[⬅️ Credits](credits.md) | [Home ⬆️](index.md)

--- a/docs/rules-definitions.md
+++ b/docs/rules-definitions.md
@@ -13,3 +13,7 @@ This document makes the following modifications from the _SRD_:
 - Resistance, vulnerability, and immunity to Poison apply to both the damage type and the Poisoned condition.
 - This document adds a new **Rhythmancy** school of magic.
 - This document adds a new **Instruments** category of magic items.
+
+---
+
+[⬅️ Chapter 6: Rhythmancy Magic Items](ch-6-rhythmancy-magic-items.md) | [Home ⬆️](index.md) | [Credits ➡️](credits.md)


### PR DESCRIPTION
- added Gathering of the Elements:
  - level 1 Evocation spell for Bards
  - choose elemental damage + secondary effect on failed Dex saves, half damage and no secondary effect on success
  - +1 mote per level increase
- added more pages to navbars (now includes Rules Definitions, Credits, and Licensing after Chapter 6: Rhythmancy Magic Items, following the order in the table of contents)
- standardized Home before Next Chapter on first chapter page's navbar