### PR TITLE
errata 2026-01-08

### DIFF
--- a/docs/ch-5-rhythmancy-spells.md
+++ b/docs/ch-5-rhythmancy-spells.md
@@ -40,7 +40,7 @@ In some cases, multiple rhythmancy spells are learned as a single song, existing
 | 5 | _[Healing Balm](#healing-balm)_ | Evocation/Rhythmancy | Bard, Ranger (Wild Composer) | — |
 | 5 | _[Inverted Song of Time](#inverted-song-of-time)_ | Abjuration/Rhythmancy | Bard | — |
 | 5 | _[Melody of Darkness](#melody-of-darkness)_ | Necromancy/Rhythmancy | Bard | C |
-| 5 | _[Ballet of the Moon and Sun](#ballet-of-the-moon-and-sun)_ | Illusion/Rhythmancy | Bard | C |
+| 5 | _[Ballet of the Moon and Sun](#ballet-of-the-moon-and-sun)_ | Enchantment/Rhythmancy | Bard | C |
 | 6 | _[The River Devil's Lament](#the-river-devils-lament)_ | Enchantment/Rhythmancy | Bard | M |
 | 7 | _[Concerto No. 3 in F minor, "Master of the Ages"](#concerto-no-3-in-f-minor-master-of-the-ages)_ | Conjuration/Rhythmancy | Bard | M |
 | 8 | _[Cast Upon the Seas](#cast-upon-the-seas)_ | Conjuration/Rhythmancy | Bard | M |
@@ -63,16 +63,16 @@ You play a soothing melody that conjures strange memories of a dream-like world.
 
 ### _Ballet of the Moon and Sun_
 
-_Level 5 Illusion/Rhythmancy (Bard)_
+_Level 5 Enchantment/Rhythmancy (Bard)_
 
 **Casting Time:** Action\
 **Range:** 30 feet\
 **Components:** V, S, M (a Musical Instrument worth 1+ GP)\
 **Duration:** Concentration, up to 1 hour
 
-You attempt to manipulate the apparent flow of time for a creature you target in range that can hear you. The target must make an Intelligence saving throw, and if you are fighting the target, they have advantage on the saving throw. On a failed save, until the spell ends, the target believes that time has passed such that it is either just after sunrise or just after sunset (whichever is the sooner of the two events).
+You attempt to manipulate the apparent flow of time for a creature you target in range that can hear you. The target must make an Wisdom saving throw, and if you are fighting the target, they have Advantage on the saving throw. On a failed save, until the spell ends, the target believes that time has passed such that it is either just after sunrise or just after sunset (whichever is the sooner of the two events).
 
-While under the effects of this spell, the creature's senses are modified to convince them of the false time of day. The target's vision makes it appear as if environments are lit by sunlight for a false daytime, or darkened by night for a false nighttime. Any other time-sensitive visuals and sounds (such as a clock's face or a rooster's morning crow) are overlaid with appropriate illusory replacements. The creature is able to see within their illusory environment based on their existing senses as if the illusions are real; for example, a creature with sunlight sensitivity suffers disadvantage on checks that rely on sight while under false daylight conditions of this spell, and a creature with darkvision similarly would be able to see in false nighttime conditions as if it were actually dark. Creatures without darkvision are granted the feature temporarily to allow them to see in dark spaces as if they were lit by illusory daylight.
+While under the effects of this spell, the creature's senses are modified to convince them of the false time of day. The target's vision makes it appear as if environments are lit by sunlight for a false daytime, or darkened by night for a false nighttime. Any other time-sensitive visuals and sounds (such as a clock's face or a rooster's morning crow) are overlaid with appropriate illusory replacements. The creature is able to see within their illusory environment based on their existing senses as if the illusions are real; for example, a creature with sunlight sensitivity suffers Disadvantage on checks that rely on sight while under false daylight conditions of this spell, and a creature with Darkvision similarly would be able to see in false nighttime conditions as if it were actually dark. Creatures without Darkvision are granted the feature temporarily to allow them to see in dark spaces as if they were lit by illusory daylight.
 
 False memories are implanted in the creature's mind, such that they believe time and events have passed normally. Modified senses and memories don't necessarily affect how a creature behaves, but the creature will make normal efforts to proceed with activities that would make sense for the given time of day. Such activities might include leaving home to work a farm, closing a business for the night, departing for a formal occasion, preparing for bed, or any other time-specific activity.
 
@@ -126,7 +126,7 @@ _Level 4 Abjuration/Rhythmancy (Bard)_
 **Components:** V, S, M (a Musical Instrument worth 1+ GP)\
 **Duration:** Concentration, up to 1 minute
 
-You perform a melody that repels the walking dead from your immediate vicinity. When an undead creature enters the spell's area of effect for the first time on a turn or starts their turn there, they must make a Wisdom saving throw. On a failed save, a creature is Frightened of you for the duration of the spell, or until they leave the spell's area of effect. Creatures that are normally immune to being Frightened have advantage on this saving throw but are otherwise not immune to the Frightened condition caused by this spell. Creatures that are immune to being Turned are not affected by this spell.
+You perform a melody that repels the walking dead from your immediate vicinity. When an undead creature enters the spell's area of effect for the first time on a turn or starts their turn there, they must make a Wisdom saving throw. On a failed save, a creature is Frightened of you for the duration of the spell, or until they leave the spell's area of effect. Creatures that are normally immune to being Frightened have Advantage on this saving throw but are otherwise not immune to the Frightened condition caused by this spell. Creatures that are immune to Turn Undead are not affected by this spell.
 
 On each of your turns, you must use a Magic action to continue playing the song. The spell ends if you don't take this Magic action by the end of your turn.
 
@@ -173,7 +173,7 @@ When you cast this spell and already have a companion, instead of making a new c
 
 If your companion is mistreated or harmed by you or any of your allies, or at their own discretion, they can choose to end their companionship to you, and you can similarly end this companionship at any time. If you already have a companion and target a new creature with this spell, the previous companionship ends. Otherwise, the companionship lasts until you or your companion dies.
 
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your companion using a Spell Slot of 2nd-level or higher, they gain a number of Temporary Hit Points equal to five times the Spell Slot level.
+_**Using a Higher-Level Spell Slot.**_ When you cast this spell to summon your companion, it gains a number of Temporary Hit Points equal to five times the spell slot level.
 
 ### _The Hawk's Call_
 
@@ -184,9 +184,9 @@ _Evocation/Rhythmancy Cantrip (Bard, Ranger (Wild Composer))_
 **Components:** V, S, M (a sprig of hawk grass; a Musical Instrument worth 1+ GP)\
 **Duration:** 1 round
 
-You play a series of sharp tones evoking the shriek of a bird of prey, summoning a spectral bird to slash its talons at a creature of your choice that you can see within range. The bird can take whatever form you choose, then makes a melee spell attack against the target. On a hit, the bird deals 1d4 Piercing damage, and the target has disadvantage on Perception checks and Dexterity saving throws they make before the end of their next turn as the bird flies in their face to distract them. On a miss, or at the start of your next turn, the bird disappears, ending the spell.
+You play a series of sharp tones evoking the shriek of a bird of prey, summoning a spectral bird to slash its talons at a creature of your choice that you can see within range. The bird can take whatever form you choose, then makes a melee spell attack against the target. On a hit, the bird deals 1d4 Piercing damage, and the target has Disadvantage on Perception checks and Dexterity saving throws they make before the end of their next turn as the bird flies in their face to distract them. On a miss, or at the start of your next turn, the bird disappears, ending the spell.
 
-The spell creates more than one bird when you reach higher levels: two birds at 5th level, three birds at 11th level, and four birds at 17th level. You can direct the birds at the same target or at different ones. Make a separate attack roll for each bird. The spell ends at the start of your next turn or if all the birds disappear.
+_**Cantrip Upgrade.**_ The spell creates two birds at level 5, three birds at level 11, and four birds at level 17. You can direct the birds at the same target or at different ones. Make a separate attack roll for each bird. The spell ends at the start of your next turn or if all the birds disappear.
 
 ### _Healing Balm_
 
@@ -231,7 +231,7 @@ _Level 1 Divination/Rhythmancy (Bard, Ranger (Wild Composer))_
 
 You play a song to yourself that stirs old memories of a childhood friend. Until the spell ends, while you are traveling or exploring within the same environment you were in when casting the spell, you can't become lost except by magical means.
 
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to the spell slot level. Additionally, until the spell ends, if magical effects cause you to become lost, as a Magic action, you can attempt to identify a valid route to take for a specific intended destination on the same plane of existence as you. Make a spellcasting ability check contested by a DC equal to 10 + the other spell's level (or DC 15 if caused by another magical effect). On a success, the magical effects obfuscating your travel are suppressed for the duration of the spell, during which time the shortest and most direct route to your destination (but not necessarily the safest route) is drawn out as a spectral golden wire on the ground. On a failed check, the spell ends immediately.
+_**Using a Higher-Level Spell Slot.**_ The duration increases to a number of hours equal to the spell slot level. Additionally, until the spell ends, if magical effects cause you to become lost, as a Magic action, you can attempt to identify a valid route to take for a specific intended destination on the same plane of existence as you. Make a spellcasting ability check contested by a DC equal to 10 + the other spell's level (or DC 15 if caused by another magical effect). On a success, the magical effects obfuscating your travel are suppressed for the duration of the spell, during which time the shortest and most direct route to your destination (but not necessarily the safest route) is drawn out as a spectral golden wire on the ground. On a failed check, the spell ends immediately.
 
 ### _Mambo Marino_
 
@@ -274,7 +274,7 @@ You attempt to diminish a creature you can see within range that can hear you. T
 
 Everything the creature is wearing and carrying changes size with them. Any item dropped by an affected creature returns to normal size at once.
 
-While reduced in this manner, the target's speed is halved; they have disadvantage on Strength checks and Strength saving throws; they lose any Resistance or Immunity they have to nonmagical damage; and all of their attacks using either natural weapons or any reduced weapons deal 3d6 less damage (this can't reduce the damage below 1).
+While reduced in this manner, the target's speed is halved; they have Disadvantage on Strength checks and Strength saving throws; they lose any Resistance or Immunity they have to nonmagical damage; and all of their attacks using either natural weapons or any reduced weapons deal 3d6 less damage (this can't reduce the damage below 1).
 
 The spell ends if you are unable to see the target.
 
@@ -300,9 +300,9 @@ _Level 1 Evocation/Rhythmancy (Bard)_
 
 You summon a storm cloud that is 10 feet tall with a 20-foot radius, centered on a point you can see within range directly above you. The spell fails if you can't see a point in the air where the storm cloud could appear (for example, if you are in a room that can't accommodate the cloud).
 
-Until the spell ends, light rain falls in the area underneath the cloud. Invisible creatures under the cloud have disadvantage on attempts to hide as the rain patters on their bodies and reveals their locations as an outline of raindrops. The cloud moves with you.
+Until the spell ends, light rain falls in the area underneath the cloud. Invisible creatures under the cloud have Disadvantage on attempts to hide as the rain patters on their bodies and reveals their locations as an outline of raindrops. The cloud moves with you.
 
-If you are outdoors in a light rain when you cast this spell, the spell affects the existing storm instead of creating a new cloud. Under such conditions, the storm becomes a heavy rain, causing the area to be lightly obscured, extinguishing open flames, and imposing disadvantage on Wisdom (Perception) checks that rely on sight or hearing. When the spell ends, the weather gradually returns to normal.
+If you are outdoors in a light rain when you cast this spell, the spell affects the existing storm instead of creating a new cloud. Under such conditions, the storm becomes a heavy rain, causing the area to be lightly obscured, extinguishing open flames, and imposing Disadvantage on Wisdom (Perception) checks that rely on sight or hearing. When the spell ends, the weather gradually returns to normal.
 
 ### _Peaceful Lullaby_
 
@@ -315,7 +315,7 @@ _Level 3 Enchantment/Rhythmancy (Bard)_
 
 You play a gentle melody in an attempt to lull a creature that can hear you in range. The target must succeed on a Wisdom saving throw or fall asleep and remain Unconscious until the spell ends, the target takes damage, or another creature takes an Action to wake them. Constructs and undead automatically succeed on this saving throw.
 
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 4 or higher, for each spell slot above 3rd, the duration increases by 1 hour, and you can target an additional creature.
+_**Using a Higher-Level Spell Slot.**_ For each spell slot level above 3, the duration increases by 1 hour, and you can target an additional creature.
 
 ### _Repel the Dark_
 
@@ -369,9 +369,9 @@ _Level 3 Evocation/Rhythmancy (Bard)_
 **Components:** V, S, M (a Musical Instrument worth 1+ GP)\
 **Duration:** 8 hours
 
-You and a partner play an empowering Duet, targeting a shared location within range. When the spell finishes casting, any creatures who remained within the spells' area of effect for the entire casting and were able to hear the entire composition have Advantage on a single d20 test of their choice that they make within the spells' duration.
+You and a partner play an empowering Duet, targeting a shared location within range. When the spell finishes casting, any creatures who remained within the spells' area of effect for the entire casting and were able to hear the entire composition have Advantage on a single D20 Test of their choice that they make within the spells' duration.
 
-_**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a d20 test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
+_**Using a Higher-Level Spell Slot.**_ When you and your partner both cast this spell at level 4 or higher, for each additional spell level, all creatures who gained Advantage on a D20 Test also gain a +1 to the roll. If the spells are cast at different levels, use the lower of the two levels. For example, if the spell is cast using a level 5 and a level 6 spell slot, creatures would gain the bonus from the level 5 casting, which would be a +2 to their roll.
 
 ### _The Sage of Earth's Calling_
 
@@ -386,7 +386,7 @@ The notes you play resonate with the world under your feet, strengthening your b
 
 Once you finish casting, until the spell ends, as long as you touch the ground, you cannot be unwillingly or forcibly removed from your location, as a magical gravitational pull holds you firm. This does not prevent you from being Grappled, but a creature Grappling you cannot separate you from the ground you stand on by any nonmagical means.
 
-Magical effects that would lift or relocate you as forced movement, such as the _levitate_ spell, end immediately and cannot target you, unless they are cast as spells at a higher level than you cast this spell. Magical effects that manipulate you into moving yourself, such as being Charmed and compelled to use your own movement, function normally.
+Magical effects that would lift or relocate you as forced movement, such as the _Levitate_ spell, end immediately and cannot target you, unless they are cast as spells at a higher level than you cast this spell. Magical effects that manipulate you into moving yourself, such as being Charmed and compelled to use your own movement, function normally.
 
 If a creature attempts to teleport or planeshift you against your will and they are not using a spell cast at a higher level than this spell, they must first succeed on a spellcasting ability check (or a Wisdom check if they do not have the ability to cast spells) contested by your Spell Save DC, or the teleport or planeshift fails to include you as a target.
 
@@ -405,7 +405,7 @@ The notes you play resonate with the air around you, lifting you upward and gran
 
 Until the spell ends, you gain a flying speed equal to your movement speed, or if you already have a flying speed, it is increased by 30 feet. You hover in place when you are not flying.
 
-As long as you are not touching the ground, the air pulses around your body, granting you advantage on checks you make to resist being Grappled or to escape the Grappled condition. If you succeed on such a check, as a Reaction, you can immediately move up to half your flying speed away with a burst of wind, and the creature that was Grappling you must succeed on a Strength saving throw against your Spell Save DC or they are knocked Prone. This movement doesn't provoke opportunity attacks.
+As long as you are not touching the ground, the air pulses around your body, granting you Advantage on D20 Tests to resist the Grappled condition. If you succeed on such a D20 Test, as a Reaction, you can immediately move up to half your flying speed away with a burst of wind, and the creature that was Grappling you must succeed on a Strength saving throw against your Spell Save DC or they are knocked Prone. This movement doesn't provoke opportunity attacks.
 
 If you are successfully forced to the ground against your will for 1 minute or longer, the spell ends.
 
@@ -418,19 +418,19 @@ _Level 1 Abjuration/Rhythmancy (Bard)_
 **Components:** V, S, M (a Musical Instrument worth 1+ GP)\
 **Duration:** 10 minutes
 
-You adjust the flow of time around you, granting you the ability to correct a recent mistake. Until this spell ends, if you fail on an attack roll, ability check, or saving throw, as a Reaction, you can immediately roll a d20 and take the greater of the two results. The first time you fail a check using this spell effect, the spell ends.
+You adjust the flow of time around you, granting you the ability to correct a recent mistake. Until this spell ends, if you fail a D20 Test, as a Reaction, you can immediately roll a d20 and take the greater of the two results. The first time you fail a check using this spell effect, the spell ends.
 
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell using a spell slot of 2nd-level or higher, the duration increases to a number of hours equal to half the spell's level.
+_**Using a Higher-Level Spell Slot.**_ The duration increases to a number of hours equal to half the spell's level.
 
-If desired, you can alter the performance of the Song of Time to a related composition to create one of the following effects, which replace the spell's normal 1st-level effects:
+If desired, you can alter the performance of the Song of Time to a related composition to create one of the following effects, which replace the spell's normal level 1 effects:
 
 #### _Song of Double Time_
 
-**Song of Double Time (3rd-level or higher).** By playing the Song of Time twice as fast, you move yourself to a moment in the near future, bypassing current events. Select any moment in time in the future up to the end of the spell's duration. You temporarily vanish from existence. At the moment in time you selected when casting the spell, you reappear in the same space from where you vanished, or in the nearest location if that space is occupied. From your perspective, no time has passed. When you reappear, the spell ends.
+**Song of Double Time (Level 3+).** By playing the Song of Time twice as fast, you move yourself to a moment in the near future, bypassing current events. Select any moment in time in the future up to the end of the spell's duration. You temporarily vanish from existence. At the moment in time you selected when casting the spell, you reappear in the same space from where you vanished, or in the nearest location if that space is occupied. From your perspective, no time has passed. When you reappear, the spell ends.
 
 #### _Inverted Song of Time_
 
-**Inverted Song of Time (5th-level or higher).** By playing the Song of Time in reverse, you anchor yourself to a moment in time, allowing yourself to complete more tasks in a short time period. Until the spell ends, your speed is doubled, you gain +2 to your AC, you have advantage on Dexterity saving throws, and you gain an additional Action on each of your turns.
+**Inverted Song of Time (Level 5+).** By playing the Song of Time in reverse, you anchor yourself to a moment in time, allowing yourself to complete more tasks in a short time period. Until the spell ends, your speed is doubled, you gain +2 to your AC, you have Advantage on Dexterity saving throws, and you gain an additional action on each of your turns.
 
 ### _Souls Entwined_
 
@@ -496,7 +496,7 @@ _Level 2 Abjuration/Rhythmancy (Bard)_
 
 You stir slumbering creatures with rousing music. When you cast this spell, choose up to three creatures within range under the effect of magical sleep that can hear you. The targets, as well as all other naturally Unconscious creatures within range that can hear you, immediately regain consciousness. Until the spell ends, magic can't put creatures within range to sleep, as long as they can still hear you.
 
-_**Using a Higher-Level Spell Slot.**_ When you cast this spell at level 3 or higher, you can target one additional creature for each slot level above 2nd.
+_**Using a Higher-Level Spell Slot.**_ You can target one additional creature for each slot level above 2.
 
 ### _Summoning of the Scarecrow_
 


### PR DESCRIPTION
- Ballet of the Moon and Sun:
  - changed to Enchantment/Rhythmancy spell
  - changed to Wisdom saving throw
- updated wording for 2024 syntax standards and ease of reading